### PR TITLE
Add call view padding on regular sized devices

### DIFF
--- a/NextcloudTalk/CallFlowLayout.swift
+++ b/NextcloudTalk/CallFlowLayout.swift
@@ -39,8 +39,8 @@ class CallFlowLayout: UICollectionViewFlowLayout {
     }
 
     func commonInit() {
-        self.minimumInteritemSpacing = 10
-        self.minimumLineSpacing = 10
+        self.minimumInteritemSpacing = 8
+        self.minimumLineSpacing = 8
         self.sectionInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
 

--- a/NextcloudTalk/CallViewController.h
+++ b/NextcloudTalk/CallViewController.h
@@ -52,6 +52,9 @@
 @property (nonatomic, strong) IBOutlet AvatarBackgroundImageView *avatarBackgroundImageView;
 @property (nonatomic, strong) IBOutlet UILabel *waitingLabel;
 @property (nonatomic, strong) IBOutlet NCChatTitleView *titleView;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *collectionViewLeftConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *collectionViewRightConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *collectionViewBottomConstraint;
 
 - (instancetype)initCallInRoom:(NCRoom *)room asUser:(NSString*)displayName audioOnly:(BOOL)audioOnly;
 - (void)toggleChatView;

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -431,15 +431,16 @@ typedef NS_ENUM(NSInteger, CallState) {
     
     NSString *videoResolution = [[[NCSettingsController sharedInstance] videoSettingsModel] currentVideoResolutionSettingFromStore];
     NSString *localVideoRes = [[[NCSettingsController sharedInstance] videoSettingsModel] readableResolution:videoResolution];
-    
+
+    // When running on MacOS the camera will always be in portrait mode
     if ([localVideoRes isEqualToString:@"Low"] || [localVideoRes isEqualToString:@"Normal"]) {
-        if (width < height) {
+        if (width < height || [NCUtils isiOSAppOnMac]) {
             localVideoSize = CGSizeMake(height * 3/4, height);
         } else {
             localVideoSize = CGSizeMake(width, width * 3/4);
         }
     } else {
-        if (width < height) {
+        if (width < height || [NCUtils isiOSAppOnMac]) {
             localVideoSize = CGSizeMake(height * 9/16, height);
         } else {
             localVideoSize = CGSizeMake(width, width * 9/16);
@@ -447,7 +448,7 @@ typedef NS_ENUM(NSInteger, CallState) {
     }
 
     UIEdgeInsets safeAreaInsets = self.view.safeAreaInsets;
-    _localVideoOriginPosition = CGPointMake(16 + safeAreaInsets.left, 80 + safeAreaInsets.top);
+    _localVideoOriginPosition = CGPointMake(16 + safeAreaInsets.left + _collectionViewLeftConstraint.constant, 80 + safeAreaInsets.top);
 
     CGRect localVideoRect = CGRectMake(_localVideoOriginPosition.x, _localVideoOriginPosition.y, localVideoSize.width, localVideoSize.height);
     
@@ -858,7 +859,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 - (void)adjustLocalVideoPositionFromOriginPosition:(CGPoint)position
 {
     UIEdgeInsets safeAreaInsets = _localVideoView.superview.safeAreaInsets;
-    UIEdgeInsets edgeInsets = UIEdgeInsetsMake(16 + _topBarView.frame.origin.y + _topBarView.frame.size.height, 16 + safeAreaInsets.left, 16 + safeAreaInsets.bottom, 16 + safeAreaInsets.right);
+    UIEdgeInsets edgeInsets = UIEdgeInsetsMake(16 + _topBarView.frame.origin.y + _topBarView.frame.size.height, 16 + safeAreaInsets.left + _collectionViewLeftConstraint.constant, 16 + safeAreaInsets.bottom + _collectionViewBottomConstraint.constant, 16 + safeAreaInsets.right + _collectionViewRightConstraint.constant);
 
     CGSize parentSize = _localVideoView.superview.bounds.size;
     CGSize viewSize = _localVideoView.bounds.size;

--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -247,6 +247,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 
     [self.collectionView.collectionViewLayout invalidateLayout];
     [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext>  _Nonnull context) {
+        [self adjustCollectionView];
         [self setLocalVideoRect];
         [self resizeScreensharingView];
         [self adjustTopBar];
@@ -257,6 +258,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 - (void)viewSafeAreaInsetsDidChange
 {
     [super viewSafeAreaInsetsDidChange];
+    [self adjustCollectionView];
     [self setLocalVideoRect];
     [self adjustTopBar];
 }
@@ -265,6 +267,7 @@ typedef NS_ENUM(NSInteger, CallState) {
 {
     [super viewWillAppear:animated];
 
+    [self adjustCollectionView];
     [self setLocalVideoRect];
     [self adjustSpeakerButton];
     [self adjustTopBar];
@@ -739,6 +742,23 @@ typedef NS_ENUM(NSInteger, CallState) {
     });
 }
 
+- (void)adjustCollectionView
+{
+    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
+        [self->_collectionViewLeftConstraint setConstant:0.0f];
+        [self->_collectionViewRightConstraint setConstant:0.0f];
+    } else {
+        [self->_collectionViewLeftConstraint setConstant:8.0f];
+        [self->_collectionViewRightConstraint setConstant:8.0f];
+    }
+
+    if (self.traitCollection.verticalSizeClass == UIUserInterfaceSizeClassCompact) {
+        [self->_collectionViewBottomConstraint setConstant:0.0f];
+    } else {
+        [self->_collectionViewBottomConstraint setConstant:8.0f];
+    }
+}
+
 - (void)adjustMoreButtonMenu
 {
     // When we target iOS 15, we might want to use an uncached UIDeferredMenuElement
@@ -1103,7 +1123,7 @@ typedef NS_ENUM(NSInteger, CallState) {
         [_localVideoView.captureSession stopRunning];
         _localVideoView.captureSession = nil;
         [_localVideoView setHidden:YES];
-        
+
         dispatch_async(dispatch_get_main_queue(), ^{
             for (NCPeerConnection *peerConnection in self->_peersInCall) {
                 // Video renderers

--- a/NextcloudTalk/CallViewController.xib
+++ b/NextcloudTalk/CallViewController.xib
@@ -15,6 +15,9 @@
                 <outlet property="avatarBackgroundImageView" destination="H1v-6g-V21" id="ASI-wy-zPa"/>
                 <outlet property="closeScreensharingButton" destination="N0N-Ny-Aeg" id="NrD-JV-Hec"/>
                 <outlet property="collectionView" destination="aUh-Z0-hO6" id="jmc-BV-dTa"/>
+                <outlet property="collectionViewBottomConstraint" destination="TOU-Pk-3pi" id="R4U-x4-psd"/>
+                <outlet property="collectionViewLeftConstraint" destination="XPT-Wv-kZY" id="daX-Mt-ctm"/>
+                <outlet property="collectionViewRightConstraint" destination="DEZ-W6-lNr" id="dhb-cd-90o"/>
                 <outlet property="hangUpButton" destination="Rl8-bS-FJ5" id="jNg-Ly-6wz"/>
                 <outlet property="localVideoView" destination="TXj-7E-NAa" id="nXn-uK-PDD"/>
                 <outlet property="lowerHandButton" destination="RpQ-sH-1qf" id="g5K-YY-Va1"/>


### PR DESCRIPTION
On regular sized devices (like iPad or Mac) we only constrained to the safe area, which can look weird depending on the device type. For regular sized devices we now adjust the padding to be inline with the cell spacing. For compact sized devices we don't do this as we want to use as much space as possible on small devices.
This also fixes the local video on Mac not having a corner radius.