### PR TITLE
Fix race-conditions in call view

### DIFF
--- a/NextcloudTalk/CallViewController.m
+++ b/NextcloudTalk/CallViewController.m
@@ -1613,7 +1613,7 @@ typedef void (^UpdateCallParticipantViewCellBlock)(CallParticipantViewCell *cell
 
 - (void)callControllerDidJoinCall:(NCCallController *)callController
 {
-    [self setCallState:CallStateWaitingParticipants];
+    [self setCallStateForPeersInCall];
 
     // Show chat if it was visible before room switch
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^(void){

--- a/NextcloudTalk/NCRoomsManager.m
+++ b/NextcloudTalk/NCRoomsManager.m
@@ -772,8 +772,9 @@ static NSInteger kNotJoiningAnymoreStatusCode = 999;
             }
         }
 
-        [[NCUserInterfaceController sharedInstance] presentCallViewController:_callViewController];
-        [self joinRoom:room.token forCall:YES];
+        [[NCUserInterfaceController sharedInstance] presentCallViewController:_callViewController withCompletionBlock:^{
+            [self joinRoom:room.token forCall:YES];
+        }];
     } else {
         NSLog(@"Not starting call due to in another call.");
     }

--- a/NextcloudTalk/NCUserInterfaceController.h
+++ b/NextcloudTalk/NCUserInterfaceController.h
@@ -32,6 +32,8 @@
 
 @class NCSplitViewController;
 
+typedef void (^PresentCallControllerCompletionBlock)(void);
+
 @interface NCUserInterfaceController : NSObject
 
 @property (nonatomic, strong) NCSplitViewController *mainViewController;
@@ -48,7 +50,7 @@
 - (void)presentAlertForPushNotification:(NCPushNotification *)pushNotification;
 - (void)presentAlertViewController:(UIAlertController *)alertViewController;
 - (void)presentChatViewController:(NCChatViewController *)chatViewController;
-- (void)presentCallViewController:(CallViewController *)callViewController;
+- (void)presentCallViewController:(CallViewController *)callViewController withCompletionBlock:(PresentCallControllerCompletionBlock)block;
 - (void)presentCallKitCallInRoom:(NSString *)token withVideoEnabled:(BOOL)video;
 - (void)presentChatForURL:(NSURLComponents *)urlComponents;
 - (void)presentLoginViewControllerForServerURL:(NSString *)serverURL withUser:(NSString *)user;

--- a/NextcloudTalk/NCUserInterfaceController.m
+++ b/NextcloudTalk/NCUserInterfaceController.m
@@ -347,10 +347,14 @@
     [_roomsTableViewController setSelectedRoomToken:chatViewController.room.token];
 }
 
-- (void)presentCallViewController:(CallViewController *)callViewController
+- (void)presentCallViewController:(CallViewController *)callViewController withCompletionBlock:(PresentCallControllerCompletionBlock)block
 {
     [_mainViewController dismissViewControllerAnimated:NO completion:nil];
-    [_mainViewController presentViewController:callViewController animated:YES completion:nil];
+    [_mainViewController presentViewController:callViewController animated:YES completion:^{
+        if (block) {
+            block();
+        }
+    }];
 }
 
 - (void)presentCallKitCallInRoom:(NSString *)token withVideoEnabled:(BOOL)video


### PR DESCRIPTION
Fixes #1162 

This PR fixes 2 race conditions.

### Missing local video
When correctly working, we have this order of events:
```
NextcloudTalk[552:23377] MM: ViewWillAppear
NextcloudTalk[552:23377] MM: ViewDidAppear
NextcloudTalk[552:23597] MM: DidCreateLocalVideoCapturere
```

But it can happen that we create the local media before the view is correctly loaded
```
NextcloudTalk[552:23967] MM: DidCreateLocalVideoCapturere
NextcloudTalk[552:23377] MM: ViewWillAppear
NextcloudTalk[552:23377] MM: ViewDidAppear
```

In this case `_localVideoView` is nil and assigning the capturer session does nothing. Our current code is not able to recover from this. This happens because we show the view and join the call in basically in parallel. Now we wait with the join until the view was presented.

### Participant details are visible all the time in a video call
In a video call the participant details should be hidden by default and can be shown by a tap. In recent versions this did not work correctly anymore, because the call state was resetted to `WaitingForParticipants` in the `callControllerDidJoinCall`. We now use the `setCallStateForPeersInCall` method to determine if there are already participants in the call and then don't "downgrade" the state from `InCall` to `WaitingForParticipants`.