### PR TITLE
Adjust message editing

### DIFF
--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -1527,7 +1527,7 @@ import UIKit
             let timestampDate = Date(timeIntervalSince1970: TimeInterval(message.lastEditTimestamp))
 
             let editInfo = UIAction(title: NSLocalizedString("Edited by", comment: "A message was edited by ...") + " " + lastEditActorDisplayName, attributes: [.disabled], handler: {_ in })
-            editInfo.subtitle = NCUtils.readableTimeOrDate(fromDate: timestampDate)
+            editInfo.subtitle = NCUtils.readableTimeAndDate(fromDate: timestampDate)
 
             actions.append(UIMenu(options: [.displayInline], children: [editInfo]))
         }

--- a/NextcloudTalk/InputbarViewController.swift
+++ b/NextcloudTalk/InputbarViewController.swift
@@ -116,6 +116,12 @@ import UIKit
         self.textInputbar.editorLeftButton.tintColor = .systemBlue
         self.textInputbar.editorRightButton.tintColor = .systemBlue
 
+        self.textInputbar.editorLeftButton.setImage(.init(systemName: "xmark"), for: .normal)
+        self.textInputbar.editorRightButton.setImage(.init(systemName: "checkmark"), for: .normal)
+        
+        self.textInputbar.editorLeftButton.setTitle("", for: .normal)
+        self.textInputbar.editorRightButton.setTitle("", for: .normal)
+
         self.navigationController?.navigationBar.tintColor = NCAppBranding.themeTextColor()
         self.navigationController?.navigationBar.barTintColor = NCAppBranding.themeColor()
         self.navigationController?.navigationBar.isTranslucent = false

--- a/NextcloudTalk/NCUtils.swift
+++ b/NextcloudTalk/NCUtils.swift
@@ -178,6 +178,18 @@ import UniformTypeIdentifiers
         return dateFormatter.string(from: date)
     }
 
+    public static func readableTimeAndDate(fromDate date: Date) -> String {
+        if Calendar.current.isDateInToday(date) {
+            return self.getTime(fromDate: date)
+        }
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .medium
+        dateFormatter.timeStyle = .short
+
+        return dateFormatter.string(from: date)
+    }
+
     public static func getTime(fromDate date: Date) -> String {
         let dateFormatter = DateFormatter()
         dateFormatter.dateStyle = .none


### PR DESCRIPTION
The current implementation of the text view has issues when translations for "Cancel" and "Save" are too big/wide. Use SF icons instead for now:
<img width="253" alt="image" src="https://github.com/nextcloud/talk-ios/assets/1580193/536053e5-897c-467a-8979-49b8fc1fd2f6">

Also fixes the displayed date time in the edit info.