### PR TITLE
fix(schedule-meeting): Show "No participants found" label when scheduling a meeting in a room without participants

### DIFF
--- a/NextcloudTalk/ScheduleMeetingSwiftUIView.swift
+++ b/NextcloudTalk/ScheduleMeetingSwiftUIView.swift
@@ -322,6 +322,11 @@ struct SelectParticipantsView: View {
             }
         }
         .navigationTitle("Meeting attendees")
+        .overlay {
+            if selectedParticipants.isEmpty {
+                Text("No participants found").foregroundStyle(.secondary)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fix #2065 