### PR TITLE
Fixed the UI not updating when the room is Locked/Unlocked

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -550,6 +550,7 @@ import SwiftUI
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveThreadMessage(notification:)), name: NSNotification.Name.NCChatControllerDidReceiveThreadMessage, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveThreadNotFound(notification:)), name: NSNotification.Name.NCChatControllerDidReceiveThreadNotFound, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveHistoryCleared(notification:)), name: NSNotification.Name.NCChatControllerDidReceiveHistoryCleared, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didReceiveConversationLocked(notification:)), name: NSNotification.Name.NCChatControllerDidReceiveConversationLocked, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveMessagesInBackground(notification:)), name: NSNotification.Name.NCChatControllerDidReceiveMessagesInBackground, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(didChangeRoomCapabilities(notification:)), name: NSNotification.Name.NCDatabaseManagerRoomCapabilitiesChanged, object: nil)
 
@@ -1856,6 +1857,18 @@ import SwiftUI
             self.hasRequestedInitialHistory = false
             self.chatController.getInitialChatHistory()
         }
+    }
+
+    func didReceiveConversationLocked(notification: Notification) {
+        if notification.object as? NCChatController != self.chatController {
+            return
+        }
+
+        guard let locked = notification.userInfo?["locked"] as? Bool
+        else { return }
+
+        self.room.readOnlyState = locked ? .readOnly : .readWrite
+        self.checkRoomControlsAvailability()
     }
 
     func didReceiveMessagesInBackground(notification: Notification) {

--- a/NextcloudTalk/Chat/NCChatController.swift
+++ b/NextcloudTalk/Chat/NCChatController.swift
@@ -20,6 +20,7 @@ public extension NSNotification.Name {
     static let NCChatControllerDidReceiveMessagesInBackground = NSNotification.Name("NCChatControllerDidReceiveMessagesInBackgroundNotification")
     static let NCChatControllerDidReceiveThreadMessage = NSNotification.Name("NCChatControllerDidReceiveThreadMessageNotification")
     static let NCChatControllerDidReceiveThreadNotFound = NSNotification.Name("NCChatControllerDidReceiveThreadNotFoundNotification")
+    static let NCChatControllerDidReceiveConversationLocked = NSNotification.Name("NCChatControllerDidReceiveConversationLocked")
 }
 
 public class NCChatController: NSObject {
@@ -798,6 +799,12 @@ public class NCChatController: NSObject {
                 userInfo["historyCleared"] = message
                 NotificationCenter.default.post(name: .NCChatControllerDidReceiveHistoryCleared, object: self, userInfo: userInfo)
                 return
+            }
+            // Notify if "conversation locked" message has been received
+            if message.systemMessage == "read_only" ||
+                message.systemMessage == "read_only_off" {
+                userInfo["locked"] = message.systemMessage == "read_only"
+                NotificationCenter.default.post(name: .NCChatControllerDidReceiveConversationLocked, object: self, userInfo: userInfo)
             }
         }
 

--- a/NextcloudTalk/NCExternalSignalingController.m
+++ b/NextcloudTalk/NCExternalSignalingController.m
@@ -656,6 +656,11 @@ NSString * const NCExternalSignalingControllerDidReceiveStoppedTypingNotificatio
 - (void)processRoomListEvent:(NSDictionary *)eventDict
 {
     NSLog(@"Refresh room list.");
+    NSDictionary *updateDict = [eventDict objectForKey:@"update"];
+    NSString *roomToken = [updateDict objectForKey:@"roomid"];
+    if (roomToken) {
+        [[NCRoomsManager sharedInstance] updateRoom:roomToken withCompletionBlock:nil];
+    }
 }
 
 - (void)processRoomParticipantsEvent:(NSDictionary *)eventDict


### PR DESCRIPTION
- Based on https://github.com/nextcloud/talk-ios/pull/2568 to make it work with chat relay.
- fixes #2082 

Updated the room upon receiving a `processRoomListEvent` in the `NCExternalSignalingController`.

Is this the right way to implement this? Not sure if updating is a heavy operation or not. On [Android](https://github.com/nextcloud/talk-android/pull/4567/files#diff-a3567d71e5bb91cd3a5b0f732565ce89ebb3edcaa51f45dfe36922cb1b4e7259R679) we have the room state updated upon receiving a new capability from the server, which is then reflected in the UI.

https://github.com/user-attachments/assets/a6f4cf8b-38e5-4364-9d7a-c2a0bf317b41

