### PR TITLE
Fix: Reply to thread original message

### DIFF
--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -978,7 +978,7 @@ import SwiftUI
         }
     }
 
-    func didPressShowThread(for message: NCChatMessage) {
+    func didPressShowThread(for message: NCChatMessage, toReply: Bool = false) {
         // Overridden in sub class
     }
 
@@ -987,7 +987,7 @@ import SwiftUI
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
             // If user press reply on the thread original message (in a normal chat view), open the thread view
             if self.thread == nil && message.isThreadOriginalMessage() {
-                self.didPressShowThread(for: message)
+                self.didPressShowThread(for: message, toReply: true)
                 return
             }
 

--- a/NextcloudTalk/BaseChatViewController.swift
+++ b/NextcloudTalk/BaseChatViewController.swift
@@ -985,6 +985,12 @@ import SwiftUI
     func didPressReply(for message: NCChatMessage) {
         // Make sure we get a smooth animation after dismissing the context menu
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            // If user press reply on the thread original message (in a normal chat view), open the thread view
+            if self.thread == nil && message.isThreadOriginalMessage() {
+                self.didPressShowThread(for: message)
+                return
+            }
+
             self.showReplyView(for: message)
         }
     }

--- a/NextcloudTalk/ChatViewController.swift
+++ b/NextcloudTalk/ChatViewController.swift
@@ -14,6 +14,7 @@ import SwiftUI
 
     // MARK: - Public var
     public var presentedInCall = false
+    public var presentKeyboardOnAppear = false
     public var chatController: NCChatController
     public var highlightMessageId = 0
 
@@ -566,6 +567,15 @@ import SwiftUI
         }
     }
 
+    public override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        if self.presentKeyboardOnAppear {
+            self.presentKeyboard(true)
+            self.presentKeyboardOnAppear = false
+        }
+    }
+
     public override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
@@ -987,11 +997,13 @@ import SwiftUI
         return canPress
     }
 
-    public override func didPressShowThread(for message: NCChatMessage) {
+    public override func didPressShowThread(for message: NCChatMessage, toReply: Bool = false) {
         guard let account = self.room.account,
               let thread = NCThread(threadId: message.threadId, inRoom: room.token, forAccountId: account.accountId),
               let chatViewController = ChatViewController(forThread: thread, inRoom: room, withAccount: account)
         else { return }
+
+        chatViewController.presentKeyboardOnAppear = toReply
 
         let navController = NCNavigationController(rootViewController: chatViewController)
         navController.presentationController?.delegate = chatViewController


### PR DESCRIPTION
Before:
The user was able to reply to a thread original message in normal chat view, the reply was automatically part of the thread and invisible in the normal chat view.

Now:
When a user tries to reply to a thread original message in normal chat view, the thread view is presented. 