### PR TITLE
fix: Status stack view alignment

### DIFF
--- a/NextcloudTalk/BaseChatTableViewCell.xib
+++ b/NextcloudTalk/BaseChatTableViewCell.xib
@@ -121,7 +121,7 @@
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="coC-95-bYv" userLabel="FooterPart">
                                         <rect key="frame" x="0.0" y="594" width="683" height="20"/>
                                         <subviews>
-                                            <stackView opaque="NO" contentMode="scaleToFill" alignment="firstBaseline" translatesAutoresizingMaskIntoConstraints="NO" id="TkE-V6-ePd" userLabel="StatusView">
+                                            <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="TkE-V6-ePd" userLabel="StatusView">
                                                 <rect key="frame" x="578" y="0.0" width="99" height="14"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="1000" text="An artificial date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YZe-JE-Hfm" userLabel="DateLabel">


### PR DESCRIPTION
Before:
![IMG_E0226](https://github.com/user-attachments/assets/cc20c746-2589-45eb-a515-c11a99399d27)

Now:
![IMG_E0225](https://github.com/user-attachments/assets/ba76f59f-a5ff-406f-9f06-2b3c1beb35f7)
