### PR TITLE
fix: Bar buttons text color for iOS 26

### DIFF
--- a/NextcloudTalk/BarButtonItemWithActivity.swift
+++ b/NextcloudTalk/BarButtonItemWithActivity.swift
@@ -10,7 +10,13 @@ class BarButtonItemWithActivity: UIBarButtonItem {
     var innerButton = UIButton()
     var activityIndicator = UIActivityIndicatorView()
 
-    lazy var textColor: UIColor = NCAppBranding.themeTextColor()
+    var textColor: UIColor {
+        if #available(iOS 26.0, *) {
+            return .label
+        } else {
+            return NCAppBranding.themeTextColor()
+        }
+    }
 
     init(image: UIImage) {
         super.init()


### PR DESCRIPTION
Before (Disabled call button):
<img width="1170" height="202" alt="grafik" src="https://github.com/user-attachments/assets/40c982c0-440f-4610-be15-0e0dfb53287c" />

Now (Disabled call button):
<img width="1166" height="188" alt="grafik" src="https://github.com/user-attachments/assets/84b00a1a-d22c-46a2-bce8-a74c7a1fb323" />

