### PR TITLE
fix: Sharing screenshots with iOS 26

### DIFF
--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -366,6 +366,11 @@
                                               NSLog(@"Shared UIImage = %@", item);
                                               UIImage *image = (UIImage *)item;
                                               [shareConfirmationVC.shareItemController addItemWithImage:image];
+                                          } else if ([(NSObject *)item isKindOfClass:[NSData class]]) {
+                                              // Screenshots starting iOS 26
+                                              NSLog(@"Shared UIImage = %@", item);
+                                              UIImage *image = [UIImage imageWithData:(NSData *)item];
+                                              [shareConfirmationVC.shareItemController addItemWithImage:image];
                                           }
                                       }];
                 return;


### PR DESCRIPTION
* Take a screenshot
* Select Share -> Nextcloud Talk
* Select conversation

-> No image preview visible, screenshot cannot be shared.
