### PR TITLE
chore: Update TOCropViewController

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -3360,7 +3360,7 @@
 			repositoryURL = "https://github.com/TimOliver/TOCropViewController";
 			requirement = {
 				kind = exactVersion;
-				version = 2.6.1;
+				version = 3.0.0;
 			};
 		};
 		1FAB2E862ACD44CF001214EB /* XCRemoteSwiftPackageReference "talk-clients-webrtc" */ = {


### PR DESCRIPTION
Support for iOS 26

**Before**
<img width="250" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-16 at 21 39 50" src="https://github.com/user-attachments/assets/9d55712a-10e0-4f6f-9765-891053258ab4" />

**After**
<img width="250" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-16 at 21 44 11" src="https://github.com/user-attachments/assets/ffcf087a-c938-462b-9c02-c54a1944442f" />
