### PR TITLE
fix: Clear messages alert text

### DIFF
--- a/NextcloudTalk/Rooms/RoomInfo/RoomInfoDestructiveSection.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/RoomInfoDestructiveSection.swift
@@ -51,7 +51,6 @@ struct RoomInfoDestructiveSection: View {
                         }
                     })
                     .alert(NSLocalizedString("Delete all messages", comment: ""), isPresented: $showClearConfirmation, actions: {
-                        Text("Do you really want to delete all messages in this conversation?")
                         Button(role: .destructive, action: {
                             clearHistory()
                         }, label: {
@@ -60,7 +59,7 @@ struct RoomInfoDestructiveSection: View {
 
                         Button("Cancel", role: .cancel) {}
                     }, message: {
-                        Text("Once a conversation is left, to rejoin a closed conversation, an invite is needed. An open conversation can be rejoined at any time.")
+                        Text("Do you really want to delete all messages in this conversation?")
                     })
                 }
 


### PR DESCRIPTION
**Before**
<img width="250" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-17 at 10 00 44" src="https://github.com/user-attachments/assets/255d52ab-5f0a-49f1-ba63-cb6a22048cef" />

**After**
<img width="250" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-17 at 10 01 56" src="https://github.com/user-attachments/assets/48fc2342-2789-41ea-b671-32b573ab5905" />
