### PR TITLE
fix: Update thread original message on thread created

### DIFF
--- a/NextcloudTalk/Chat/NCChatController.m
+++ b/NextcloudTalk/Chat/NCChatController.m
@@ -215,14 +215,11 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
 
         if (message.isThreadCreatedMessage) {
             NCThread *thread = [NCThread createThreadFromMessage:message andAccountId:message.accountId];
+
             if (thread) {
                 [realm addObject:thread];
             }
-            // Do not use parent message for updating already stored message
-            continue;
-        }
-
-        if (message.isThreadMessage) {
+        } else if (message.isThreadMessage) {
             [NCThread updateThreadWithThreadMessage:message];
         }
 


### PR DESCRIPTION
* Ref https://github.com/nextcloud/spreed/issues/16160

We have the update functionality already, but it is skipped for `thread_created` messages. I think it's a relict of the first thread implementation that we had. Not sure if I overlook something here?