### PR TITLE
fix: Dismiss keyboard when showing the context menu

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -3227,6 +3227,8 @@ import SwiftUI
             self.contextMenuMessageView?.layer.cornerRadius = 10
             self.contextMenuMessageView?.layer.mask = nil
         }
+
+        self.textView.resignFirstResponder()
     }
 
     public override func tableView(_ tableView: UITableView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {


### PR DESCRIPTION
When the keyboard is dismissed due to showing the context menu and then is shown again, the notification contains the wrong size

```
slk_didShowOrHideKeyboard: NSConcreteNotification 0x12a8dcb60 {name = UIKeyboardDidShowNotification; object = <UIScreen: 0x107208780; bounds: {{0, 0}, {375, 812}}; mode: <UIScreenMode: 0x1072e4ee0; size = 1125.000000 x 2436.000000>>; userInfo = {
  UIKeyboardAnimationCurveUserInfoKey = 7;
  UIKeyboardAnimationDurationUserInfoKey = "0.3833";
  UIKeyboardBoundsUserInfoKey = "NSRect: {{0, 0}, {375, 0}}";
  UIKeyboardCenterBeginUserInfoKey = "NSPoint: {187.5, 812}";
  UIKeyboardCenterEndUserInfoKey = "NSPoint: {187.5, 812}";
  UIKeyboardFrameBeginUserInfoKey = "NSRect: {{0, 812}, {375, 0}}";
  UIKeyboardFrameEndUserInfoKey = "NSRect: {{0, 812}, {375, 0}}";
  UIKeyboardIsLocalUserInfoKey = 1;
}}
```

As a workaround, we now resign the first responder when displaying the context menu.