### PR TITLE
fix: Correctly parse inCall flag for room participants

### DIFF
--- a/NextcloudTalk/Rooms/NCRoomParticipant.swift
+++ b/NextcloudTalk/Rooms/NCRoomParticipant.swift
@@ -44,7 +44,6 @@ public class NCRoomParticipant: NSObject {
         self.attendeeId = dictionary["attendeeId"] as? Int ?? 0
         self.actorId = dictionary["actorId"] as? String
         self.displayName = dictionary["displayName"] as? String ?? ""
-        self.inCall = dictionary["inCall"] as? CallFlag ?? []
         self.lastPing = dictionary["lastPing"] as? Int ?? 0
         self.sessionId = dictionary["sessionId"] as? String
         self.sessionIds = dictionary["sessionIds"] as? [String]
@@ -60,6 +59,10 @@ public class NCRoomParticipant: NSObject {
            let participantType = NCParticipantType(rawValue: participantTypeRaw) {
 
             self.participantType = participantType
+        }
+
+        if let callFlagRaw = dictionary["inCall"] as? Int {
+            self.inCall = CallFlag(rawValue: callFlagRaw)
         }
 
         // Optional attributes

--- a/NextcloudTalk/Rooms/RoomInfo/RoomInfoParticipantsSection.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/RoomInfoParticipantsSection.swift
@@ -121,7 +121,7 @@ struct RoomInfoParticipantsSection: View {
                         ContactsTableViewCellWrapper(room: $room, participant: $participant)
                             .frame(height: 72) // Height set in the XIB file
                     }
-                    .listRowInsets(.init())
+                    .listRowInsets(.init(top: 0, leading: 0, bottom: 0, trailing: 12))
                     .alignmentGuide(.listRowSeparatorLeading) { _ in
                         72
                     }

--- a/NextcloudTalkTests/Unit/UnitNCRoomParticipantTest.swift
+++ b/NextcloudTalkTests/Unit/UnitNCRoomParticipantTest.swift
@@ -71,4 +71,51 @@ final class UnitNCRoomParticipantTest: TestBaseRealm {
 
         XCTAssertEqual(sorted, expectedParticipants)
     }
+
+    func testInitWithDictionary() throws {
+        let dataJson = """
+            {
+                    "roomToken": "tok3n",
+                    "inCall": 7,
+                    "lastPing": 1761683745,
+                    "sessionIds": [
+                        "session1",
+                        "session2"
+                    ],
+                    "participantType": 1,
+                    "attendeeId": 72,
+                    "actorId": "admin",
+                    "actorType": "users",
+                    "displayName": "admin",
+                    "permissions": 254,
+                    "attendeePermissions": 0,
+                    "attendeePin": "",
+                    "phoneNumber": "",
+                    "callId": "",
+                    "status": "busy",
+                    "statusIcon": "💬",
+                    "statusMessage": "In a call",
+                    "statusClearAt": null
+            }
+            """
+
+        // swiftlint:disable:next force_cast
+        let participantdict = try JSONSerialization.jsonObject(with: dataJson.data(using: .utf8)!) as! [String: Any]
+        let participant = NCRoomParticipant(dictionary: participantdict)
+
+        XCTAssertEqual(participant.attendeeId, 72)
+        XCTAssertEqual(participant.actorId, "admin")
+        XCTAssertEqual(participant.actorType, .user)
+        XCTAssertEqual(participant.participantType, .owner)
+        XCTAssertEqual(participant.displayName, "admin")
+        XCTAssertEqual(participant.lastPing, 1761683745)
+        XCTAssertEqual(participant.sessionIds?[0], "session1")
+        XCTAssertEqual(participant.sessionIds?[1], "session2")
+        XCTAssertEqual(participant.inCall, [.inCall, .withAudio, .withVideo])
+        XCTAssertEqual(participant.status, "busy")
+        XCTAssertEqual(participant.statusIcon, "💬")
+        XCTAssertEqual(participant.statusMessage, "In a call")
+        XCTAssertNil(participant.userId)
+    }
+
 }


### PR DESCRIPTION
Participants were always set to disconnected. Easiest way to test is to open the conversation list while a call is ongoing. With that PR microphone/camera are visible again on the participants.