### PR TITLE
chore: Add gesture recognizer to wrapper view as well

### DIFF
--- a/NextcloudTalk/Chat/Chat views/OutOfOfficeView.swift
+++ b/NextcloudTalk/Chat/Chat views/OutOfOfficeView.swift
@@ -82,6 +82,7 @@ import SwiftyAttributes
 
         subtitle.addGestureRecognizer(tapGestureRecognizer)
         stackView.addGestureRecognizer(tapGestureRecognizer)
+        wrapperView.addGestureRecognizer(tapGestureRecognizer)
     }
 
     func tapTextView() {


### PR DESCRIPTION
Sometimes the tap was not recognized, we need to add it to the wrapper view as well.