### PR TITLE
chore: Remove iOS 26.0 specific splitview workaround

### DIFF
--- a/NextcloudTalk/User Interface/NCSplitViewController.swift
+++ b/NextcloudTalk/User Interface/NCSplitViewController.swift
@@ -80,8 +80,10 @@
                 super.showDetailViewController(navController, sender: sender)
 
                 if #available(iOS 26.0, *) {
-                    // Fix weird animation on iOS 26
-                    vc.view.layoutIfNeeded()
+                    if #unavailable(iOS 26.1) {
+                        // Fix weird animation on iOS 26
+                        vc.view.layoutIfNeeded()
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixed in 26.1.