### PR TITLE
feat: Account picker improvements

### DIFF
--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -612,6 +612,8 @@ typedef enum RoomsSections {
 
             if (account.unreadBadgeNumber > 0) {
                 switchAccountAction.subtitle = [NSString localizedStringWithFormat:NSLocalizedString(@"%ld notifications", nil), (long)account.unreadBadgeNumber];
+            } else {
+                switchAccountAction.subtitle = [account.server stringByReplacingOccurrencesOfString:@"https://" withString:@""];
             }
 
             [inactiveAccounts addObject:switchAccountAction];

--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -619,6 +619,18 @@ typedef enum RoomsSections {
             [inactiveAccounts addObject:switchAccountAction];
         }
 
+        if (inactiveAccounts.count > 0) {
+            TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
+            UIImage *accountImage = [[NCAPIController sharedInstance] userProfileImageForAccount:activeAccount withStyle:self.traitCollection.userInterfaceStyle];
+            if (accountImage) {
+                accountImage = [NCUtils roundedImageFromImage:accountImage];
+            }
+            UIAction *activeAccountAction = [UIAction actionWithTitle:activeAccount.userDisplayName image:accountImage identifier:nil handler:^(UIAction *action) {}];
+            activeAccountAction.subtitle = [activeAccount.server stringByReplacingOccurrencesOfString:@"https://" withString:@""];
+            activeAccountAction.state = UIMenuElementStateOn;
+            [inactiveAccounts insertObject:activeAccountAction atIndex:0];
+        }
+
         UIMenu *inactiveAccountsMenu = [UIMenu menuWithTitle:@""
                                                        image:nil
                                                   identifier:nil

--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -624,6 +624,12 @@ typedef enum RoomsSections {
                                                   identifier:nil
                                                      options:UIMenuOptionsDisplayInline
                                                     children:inactiveAccounts];
+        if (@available(iOS 17.4, *)) {
+            UIMenuDisplayPreferences *displayPreferences = [[UIMenuDisplayPreferences alloc] init];
+            displayPreferences.maximumNumberOfTitleLines = 1;
+
+            inactiveAccountsMenu.displayPreferences = displayPreferences;
+        }
 
         completion(@[inactiveAccountsMenu]);
     }];


### PR DESCRIPTION
- [x] Show account's server URL
- [x] Show active account

| Before | After |
| --- | --- |
| ![IMG_E0262](https://github.com/user-attachments/assets/e3f7c353-6584-44ae-a02f-28ee3def5b1b) | ![IMG_E0263](https://github.com/user-attachments/assets/669458cc-ab23-4db2-b3a9-d9d2b529e179) |

Fixes https://github.com/nextcloud/talk-ios/issues/2266

