### PR TITLE
Feat: Cache message height

### DIFF
--- a/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
+++ b/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
@@ -1,0 +1,31 @@
+//
+// SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+public class NCChatMessageHeightCache {
+
+    private let internalCache = NSCache<NSString, NSNumber>()
+
+    private var cachedWidth: CGFloat = 0
+
+    public func getHeight(forMessage message: NCChatMessage, forWidth width: CGFloat) -> CGFloat? {
+        guard self.cachedWidth == width else { return nil }
+
+        return self.internalCache.object(forKey: String(message.messageId) as NSString) as? CGFloat
+    }
+
+    public func setHeight(forMessage message: NCChatMessage, forWidth width: CGFloat, withHeight height: CGFloat) {
+        if self.cachedWidth != width {
+            self.internalCache.removeAllObjects()
+            self.cachedWidth = width
+        }
+
+        self.internalCache.setObject(height as NSNumber, forKey: String(message.messageId) as NSString)
+    }
+
+    public func removeHeight(forMessage message: NCChatMessage) {
+        self.internalCache.removeObject(forKey: String(message.messageId) as NSString)
+    }
+
+}

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
@@ -52,14 +52,17 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
     func testCellHeight() throws {
         // Normal chat message
         testMessage.message = "test"
+        testMessage.messageId = 1
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 101.0)
 
         // Multiline chat message
         testMessage.message = "test\nasd\nasd"
+        testMessage.messageId = 2
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 141.0)
 
         // Normal chat message with reaction
         testMessage.message = "test"
+        testMessage.messageId = 3
         testMessage.setOrUpdateTemporaryReaction("👍", state: .added)
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 141.0)
     }
@@ -68,9 +71,11 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
         // Grouped chat message
         testMessage.message = "test"
         testMessage.isGroupMessage = true
+        testMessage.messageId = 1
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 71.0)
 
         // Grouped chat message with reaction
+        testMessage.messageId = 2
         testMessage.setOrUpdateTemporaryReaction("👍", state: .added)
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 111.0)
     }
@@ -96,6 +101,7 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
     func testCellWithUrlHeight() throws {
         // Chat message with URL preview
         testMessage.message = "test - https://nextcloud.com"
+        testMessage.messageId = 1
 
         updateCapabilities { cap in
             cap.referenceApiSupported = true
@@ -105,6 +111,7 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
 
         // Test URL with grouped message
         testMessage.isGroupMessage = true
+        testMessage.messageId = 2
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 176.0)
     }
 

--- a/NextcloudTalkTests/Unit/UnitNCChatMessageHeightCache.swift
+++ b/NextcloudTalkTests/Unit/UnitNCChatMessageHeightCache.swift
@@ -1,0 +1,38 @@
+//
+// SPDX-FileCopyrightText: 2024 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitNCChatMessageHeightCache: XCTestCase {
+
+    func testMessageHeightCache() throws {
+        let cache = NCChatMessageHeightCache()
+
+        let message1 = NCChatMessage()
+        message1.messageId = 123
+
+        let message2 = NCChatMessage()
+        message2.messageId = 345
+
+        cache.setHeight(forMessage: message1, forWidth: 100, withHeight: 50)
+        cache.setHeight(forMessage: message2, forWidth: 100, withHeight: 60)
+        XCTAssertEqual(cache.getHeight(forMessage: message1, forWidth: 100), 50)
+        XCTAssertEqual(cache.getHeight(forMessage: message2, forWidth: 100), 60)
+
+        cache.setHeight(forMessage: message1, forWidth: 200, withHeight: 70)
+        XCTAssertEqual(cache.getHeight(forMessage: message1, forWidth: 200), 70)
+
+        XCTAssertNil(cache.getHeight(forMessage: message1, forWidth: 100))
+        XCTAssertNil(cache.getHeight(forMessage: message2, forWidth: 100))
+        XCTAssertNil(cache.getHeight(forMessage: message2, forWidth: 200))
+
+        cache.setHeight(forMessage: message2, forWidth: 200, withHeight: 80)
+        cache.removeHeight(forMessage: message1)
+        XCTAssertNil(cache.getHeight(forMessage: message1, forWidth: 200))
+        XCTAssertEqual(cache.getHeight(forMessage: message2, forWidth: 200), 80)
+    }
+
+}


### PR DESCRIPTION
The height is called very frequently on scrolling, since we already have the height from the initial layout pass, we should cache it.