### PR TITLE
fix: Don't cache height of temporary and system messages

### DIFF
--- a/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
+++ b/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
@@ -10,7 +10,7 @@ public class NCChatMessageHeightCache {
     private var cachedWidth: CGFloat = 0
 
     public func getHeight(forMessage message: NCChatMessage, forWidth width: CGFloat) -> CGFloat? {
-        guard self.cachedWidth == width else { return nil }
+        guard self.cachedWidth == width, message.messageId > 0, !message.isSystemMessage else { return nil }
 
         return self.internalCache.object(forKey: String(message.messageId) as NSString) as? CGFloat
     }


### PR DESCRIPTION
How to reproduce:
* Write "A" in a chat
* Now write a multiline message
* Notice that the temporary message has the wrong height

For system messages we disable the cache for now, because of the collapsing. Can handle that correctly in a followup.