### PR TITLE
fix: Remove cached height on newly downloaded preview

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -3703,6 +3703,7 @@ import SwiftUI
             }
         }
 
+        self.messageHeightCache.removeHeight(forMessage: message)
         self.tableView?.beginUpdates()
         self.tableView?.endUpdates()
 


### PR DESCRIPTION
Missed it, because we do not reload the rows there, but only the height.
We should probably move the reloading to a common method in a follow-up...