### PR TITLE
fix: Change cache key to take grouping into account

### DIFF
--- a/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
+++ b/NextcloudTalk/Chat/NCChatMessageHeightCache.swift
@@ -9,10 +9,16 @@ public class NCChatMessageHeightCache {
 
     private var cachedWidth: CGFloat = 0
 
+    private func getCacheKey(forMessage message: NCChatMessage) -> NSString {
+        let key = "\(String(message.messageId))-\(message.isGroupMessage)"
+
+        return key as NSString
+    }
+
     public func getHeight(forMessage message: NCChatMessage, forWidth width: CGFloat) -> CGFloat? {
         guard self.cachedWidth == width, message.messageId > 0, !message.isSystemMessage else { return nil }
 
-        return self.internalCache.object(forKey: String(message.messageId) as NSString) as? CGFloat
+        return self.internalCache.object(forKey: getCacheKey(forMessage: message)) as? CGFloat
     }
 
     public func setHeight(forMessage message: NCChatMessage, forWidth width: CGFloat, withHeight height: CGFloat) {
@@ -21,11 +27,11 @@ public class NCChatMessageHeightCache {
             self.cachedWidth = width
         }
 
-        self.internalCache.setObject(height as NSNumber, forKey: String(message.messageId) as NSString)
+        self.internalCache.setObject(height as NSNumber, forKey: getCacheKey(forMessage: message))
     }
 
     public func removeHeight(forMessage message: NCChatMessage) {
-        self.internalCache.removeObject(forKey: String(message.messageId) as NSString)
+        self.internalCache.removeObject(forKey: getCacheKey(forMessage: message))
     }
 
 }


### PR DESCRIPTION
How to reproduce:
* User A writes messages that group together
* Show context menu of grouped message 

Since the message height was cached with grouping, the height is not correct for context menu, which shows the non-grouped message.