### PR TITLE
fix: Crash when selecting a room while in a transition

### DIFF
--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -1822,6 +1822,13 @@ typedef enum RoomsSections {
         return;
     }
 
+    if (self.navigationController.transitionCoordinator != nil) {
+        // In case we are currently in a transition (e.g. swipe back from a conversation),
+        // we don't want to present any new view controller, as that leads to crashes on iOS >= 26
+        [self removeRoomSelection];
+        return;
+    }
+
     if (tableView == self.tableView && indexPath.section == kRoomsSectionPendingFederationInvitation) {
         FederationInvitationTableViewController *federationInvitationVC = [[FederationInvitationTableViewController alloc] init];
         NCNavigationController *navigationController = [[NCNavigationController alloc] initWithRootViewController:federationInvitationVC];


### PR DESCRIPTION
How to test:
* Be in a conversation
* Leave the conversation
* While the transitioning to the room list is ongoing, tap the screen multiple times to select another room from the partly visible room list

Without this PR: 💣 
With this PR: Nothing

Hopefully fixes some of the weird crashes on AppStore Connect.