### PR TITLE
fix: Do not use "many" in English plurals translations

### DIFF
--- a/NextcloudTalk/en.lproj/Localizable.stringsdict
+++ b/NextcloudTalk/en.lproj/Localizable.stringsdict
@@ -48,8 +48,6 @@
             <string>ld</string>
             <key>one</key>
             <string>%ld participant in this call</string>
-            <key>many</key>
-            <string>%ld participants in this call</string>
             <key>other</key>
             <string>%ld participants in this call</string>
         </dict>


### PR DESCRIPTION
Trying to fix transifex (part 3)