### PR TITLE
fix: Message retrieval

### DIFF
--- a/NextcloudTalk/Network/NCAPIController.m
+++ b/NextcloudTalk/Network/NCAPIController.m
@@ -647,6 +647,12 @@ NSInteger const kReceivedChatMessagesLimit = 100;
     NSString *endpoint = [NSString stringWithFormat:@"chat/%@", encodedToken];
     NSInteger chatAPIVersion = [self chatAPIVersionForAccount:account];
     NSString *URLString = [self getRequestURLForEndpoint:endpoint withAPIVersion:chatAPIVersion forAccount:account];
+
+    if (limit <= 0) {
+        // Ensure we don't try to request an invalid number of messages (although there's a limit server side)
+        limit = kReceivedChatMessagesLimit;
+    }
+
     NSDictionary *parameters = @{@"lookIntoFuture" : history ? @(0) : @(1),
                                  @"limit" : @(MIN(kReceivedChatMessagesLimit, limit)),
                                  @"timeout" : timeout ? @(30) : @(0),


### PR DESCRIPTION
We limit the retrieval to 100 messages, but the server has a limit of 200, so make sure to explicitly use "our" limit.