### PR TITLE
fix: Ensure message width is correctly calculated with quotes

### DIFF
--- a/NextcloudTalk/Chat/Chat views/MessageBodyTextView.m
+++ b/NextcloudTalk/Chat/Chat views/MessageBodyTextView.m
@@ -41,6 +41,24 @@
     return self;
 }
 
+- (CGSize)intrinsicContentSize {
+    CGSize superSize = [super intrinsicContentSize];
+
+    // When a paragraphStyle with firstLineHeadIndent/headIndent is used, the
+    // intrinsicContentSize might not be accurate and the last word/character is wrapped,
+    // due to the size being too small. In that case usedRectForTextContainer reports
+    // a non-zero x value, we add to the width of the intrinsicContentSize
+    if (superSize.width < UINT16_MAX) {
+        CGRect usedRect = [self.layoutManager usedRectForTextContainer:self.textContainer];
+
+        if (usedRect.origin.x > 0) {
+            return CGSizeMake(superSize.width + usedRect.origin.x, superSize.height);
+        }
+    }
+
+    return superSize;
+}
+
 - (BOOL)canPerformAction:(SEL)action withSender:(id)sender
 {
     return NO;

--- a/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitBaseChatViewControllerTest.swift
@@ -222,12 +222,4 @@ final class UnitBaseChatViewControllerTest: TestBaseRealm {
         XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 300), 171.0)
     }
 
-    /*
-    func testCellWithMarkdownQuoteHeight() throws {
-        // Normal chat message
-        testMessage.message = "> 1234567890123456789012345678901"
-        XCTAssertEqual(baseController.getCellHeight(for: testMessage, with: 372), 96.0)
-    }
-     */
-
 }

--- a/NextcloudTalkTests/Unit/Chat/UnitMessageBodyTextViewTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitMessageBodyTextViewTest.swift
@@ -1,0 +1,25 @@
+//
+// SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import XCTest
+@testable import NextcloudTalk
+
+final class UnitMessageBodyTextViewTest: TestBaseRealm {
+
+    func testCellWithMarkdownQuoteHeight() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let testMessage = NCChatMessage(dictionary: [:], andAccountId: activeAccount.accountId)!
+
+        // Markdown message
+        testMessage.message = "> 1234567890123456789012345678"
+        testMessage.isMarkdownMessage = true
+
+        let messageTextView = MessageBodyTextView()
+        messageTextView.attributedText = testMessage.parsedMarkdownForChat()
+
+        XCTAssertEqual(messageTextView.intrinsicContentSize, CGSize(width: 259, height: 20))
+    }
+
+}


### PR DESCRIPTION
* Partly resolves https://github.com/nextcloud/talk-ios/issues/2302

See also https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/TextLayout/Tasks/StringHeight.html