### PR TITLE
fix: Show timezone offset even without other profile infos

### DIFF
--- a/NextcloudTalk/Rooms/RoomInfo/ProfileInfo.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/ProfileInfo.swift
@@ -48,7 +48,7 @@ public struct ProfileInfo {
     }
 
     public func hasAnyInformation() -> Bool {
-        return role != nil || pronouns != nil || organisation != nil || address != nil
+        return role != nil || pronouns != nil || organisation != nil || address != nil || timezoneOffset != nil
     }
 
 }


### PR DESCRIPTION
Some people don't have profile information, but it is still useful to show the timezone offset if available.