### PR TITLE
OOO/Pinned message view label calculation

### DIFF
--- a/NextcloudTalk/Chat/Chat views/OutOfOfficeView.swift
+++ b/NextcloudTalk/Chat/Chat views/OutOfOfficeView.swift
@@ -160,6 +160,9 @@ import SwiftyAttributes
 
         guard let font = subtitle.font else { return }
 
+        // Ensure the labels are correctly sized at this point
+        self.stackView.layoutSubviews()
+
         let singleLineHeight = ceil(font.lineHeight + font.leading)
         let maxViewHeight = singleLineHeight * maxNumberOfLines
         let maxTextSize = ceil(subtitle.sizeThatFits(CGSize(width: subtitle.frame.width, height: CGFloat.greatestFiniteMagnitude)).height)

--- a/NextcloudTalk/Chat/Chat views/PinnedMessageView.swift
+++ b/NextcloudTalk/Chat/Chat views/PinnedMessageView.swift
@@ -171,6 +171,9 @@ protocol PinnedMessageViewDelegate: AnyObject {
 
         guard let font = subtitle.font else { return }
 
+        // Ensure the labels are correctly sized at this point
+        self.stackView.layoutSubviews()
+
         let singleLineHeight = ceil(font.lineHeight + font.leading)
         let maxViewHeight = singleLineHeight * maxNumberOfLines
         let maxTextSize = ceil(subtitle.sizeThatFits(CGSize(width: subtitle.frame.width, height: CGFloat.greatestFiniteMagnitude)).height)


### PR DESCRIPTION
Otherwise the label is not layed out yet and therefore we calculate the height with a wrong value. This leads to more lines being shown, than expected.
Same is possible in pinned message view.