### PR TITLE
fix: Unread marker for thread after background check

### DIFF
--- a/NextcloudTalk/Chat/NCChatController.m
+++ b/NextcloudTalk/Chat/NCChatController.m
@@ -175,7 +175,7 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
 
 - (NSArray *)getNewStoredMessagesInBlock:(NCChatBlock *)chatBlock sinceMessageId:(NSInteger)messageId
 {
-    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND messageId > %ld AND messageId <= %ld", _account.accountId, _room.token, (long)messageId, (long)chatBlock.newestMessageId];
+    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND messageId > %ld AND messageId <= %ld AND (threadId == 0 OR threadId == messageId)", _account.accountId, _room.token, (long)messageId, (long)chatBlock.newestMessageId];
 
     if ([self isThreadController]) {
         query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND threadId = %ld AND messageId > %ld AND messageId <= %ld", _account.accountId, _room.token, _threadId, (long)messageId, (long)chatBlock.newestMessageId];


### PR DESCRIPTION
We sometimes observe a unread marker at the bottom of a chat, because of a message posted in a thread.

How to reproduce:
* Have a message in the chat
* Post a message in a thread
* When entering a chat, you observe _no_ unread marker
* Put the app in the background (while in chat) and open it again
* See unread marker now at the bottom

It happens because we check for new messages (`checkForNewStoredMessages` in ChatViewController), but fail to filter thread messages.