### PR TITLE
fix: New message check with quotes

### DIFF
--- a/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
@@ -443,6 +443,7 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
             activityIndicator.strokeWidth = 1.5
             activityIndicator.cycleColors = [.secondaryLabel]
             activityIndicator.startAnimating()
+            activityIndicator.accessibilityIdentifier = "MessageSending"
             activityIndicator.widthAnchor.constraint(equalToConstant: 20).isActive = true
 
             self.statusView.addArrangedSubview(activityIndicator)

--- a/NextcloudTalk/Chat/NCChatController.m
+++ b/NextcloudTalk/Chat/NCChatController.m
@@ -175,7 +175,7 @@ NSString * const NCChatControllerDidReceiveThreadMessageNotification            
 
 - (NSArray *)getNewStoredMessagesInBlock:(NCChatBlock *)chatBlock sinceMessageId:(NSInteger)messageId
 {
-    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND messageId > %ld AND messageId <= %ld AND (threadId == 0 OR threadId == messageId)", _account.accountId, _room.token, (long)messageId, (long)chatBlock.newestMessageId];
+    NSPredicate *query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND messageId > %ld AND messageId <= %ld AND (isThread == 0 OR threadId == 0 OR threadId == messageId)", _account.accountId, _room.token, (long)messageId, (long)chatBlock.newestMessageId];
 
     if ([self isThreadController]) {
         query = [NSPredicate predicateWithFormat:@"accountId = %@ AND token = %@ AND threadId = %ld AND messageId > %ld AND messageId <= %ld", _account.accountId, _room.token, _threadId, (long)messageId, (long)chatBlock.newestMessageId];

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -130,6 +130,43 @@ final class UIRoomTest: XCTestCase {
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))
     }
 
+    func testMessageQuoting() {
+        let app = launchAndLogin()
+        let newConversationName = "QuoteTest"
+
+        // Create a new test conversion
+        self.createConversation(for: app, with: newConversationName)
+
+        // Send a test message
+        let testMessage = "TestMessage"
+        let replyMessage = "ReplyMessage"
+
+        let toolbar = app.toolbars["Toolbar"]
+        let textView = toolbar.textViews["Write message, @ to mention someone …"]
+        XCTAssert(textView.waitForExistence(timeout: TestConstants.timeoutShort))
+        textView.tap()
+        app.typeText(testMessage)
+        let sendMessageButton = toolbar.buttons["Send message"]
+        sendMessageButton.tap()
+
+        // Wait for temporary message to be replaced
+        let messageSentImage = app.images["MessageSent"]
+        XCTAssert(messageSentImage.waitForExistence(timeout: TestConstants.timeoutShort))
+
+        // Open context menu
+        messageSentImage.press(forDuration: 2.0)
+
+        // Start a reply
+        XCTAssert(messageSentImage.waitForExistence(timeout: TestConstants.timeoutShort))
+        waitForReady(object: app.buttons["Reply"]).tap()
+
+        // Send message and check if temporary message is replaced
+        textView.tap()
+        app.typeText(replyMessage)
+        sendMessageButton.tap()
+        XCTAssert(app.otherElements["MessageSending"].waitForNonExistence(timeout: TestConstants.timeoutShort))
+    }
+
     func testChatViewControllerMentions() {
         let app = launchAndLogin()
         let newConversationName = "MentionTest 🇨🇨"


### PR DESCRIPTION
* Regression from https://github.com/nextcloud/talk-ios/pull/2335  :(

When a message has a parent (independent of own message or from other), these messages have a threadId (threadId == parent.messageId), so the check in the PR incorrectly filters messages with quotes out.