### PR TITLE
feat: Schedule messages

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -538,6 +538,7 @@
 				NCMessageLocationParameter.m,
 				NCMessageParameter.m,
 				NCPoll.m,
+				ScheduledMessage.swift,
 			);
 			target = 2CC0014E24A1F0E900A20167 /* NotificationServiceExtension */;
 		};
@@ -569,6 +570,7 @@
 				NCMessageLocationParameter.m,
 				NCMessageParameter.m,
 				NCPoll.m,
+				ScheduledMessage.swift,
 			);
 			target = 2C62AFA224C08845007E460A /* ShareExtension */;
 		};
@@ -589,6 +591,7 @@
 				NCMessageLocationParameter.m,
 				NCMessageParameter.m,
 				NCPoll.m,
+				ScheduledMessage.swift,
 			);
 			target = 1FF2FD5A2AB99CCB000C9905 /* BroadcastUploadExtension */;
 		};
@@ -609,6 +612,7 @@
 				NCMessageLocationParameter.m,
 				NCMessageParameter.m,
 				NCPoll.m,
+				ScheduledMessage.swift,
 			);
 			target = 1FA93D9B2D70FCC200DF6CDF /* TalkIntents */;
 		};

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -765,7 +765,7 @@ import SwiftUI
                     replyToMessage = replyMessageView.message
                 }
 
-                try await NCAPIController.sharedInstance().scheduleMessage(self.textView.text, inRoom: self.room.token, sendAt: timestamp, replyTo: replyToMessage?.messageId, threadId: self.thread?.threadId, forAccount: self.account)
+                try await NCAPIController.sharedInstance().scheduleMessage(self.textView.text, inRoom: self.room.token, sendAt: timestamp, replyTo: replyToMessage?.messageId, silent: silently, threadId: self.thread?.threadId, forAccount: self.account)
                 NotificationPresenter.shared().present(text: NSLocalizedString("Message successfully scheduled", comment: ""), dismissAfterDelay: 5.0, includedStyle: .success)
 
                 self.clearInputAfterSend()

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -704,7 +704,13 @@ import SwiftUI
 
     func showVoiceMessageRecordButton() {
         self.rightButton.setTitle("", for: .normal)
-        self.rightButton.setImage(UIImage(systemName: "mic"), for: .normal)
+
+        if self.room.hasScheduledMessages {
+            self.rightButton.setImage(UIImage(systemName: "clock"), for: .normal)
+        } else {
+            self.rightButton.setImage(UIImage(systemName: "mic"), for: .normal)
+        }
+
         self.rightButton.tag = sendButtonTagVoice
         self.rightButton.accessibilityLabel = NSLocalizedString("Record voice message", comment: "")
         self.rightButton.accessibilityHint = NSLocalizedString("Tap and hold to record a voice message", comment: "")
@@ -738,6 +744,40 @@ import SwiftUI
         let messageParameters = NCMessageParameter.messageParametersJSONString(from: self.mentionsDict) ?? ""
         self.sendChatMessage(message: self.textView.text, withParentMessage: replyToMessage, messageParameters: messageParameters, silently: silently)
 
+        self.clearInputAfterSend()
+    }
+
+    func sendCurrentMessageLater(silently: Bool) {
+        Task { @MainActor in
+            let startingDate = Calendar.current.date(byAdding: .hour, value: 1, to: Date())
+            let minimumDate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())
+
+            self.datePickerTextField.setupDatePicker(startingDate: startingDate, minimumDate: minimumDate)
+
+            let (buttonTapped, selectedDate) = await self.datePickerTextField.getDate()
+            guard buttonTapped == .done, let selectedDate else { return }
+
+            do {
+                let timestamp = Int(selectedDate.timeIntervalSince1970)
+                var replyToMessage: NCChatMessage?
+
+                if let replyMessageView, replyMessageView.isVisible {
+                    replyToMessage = replyMessageView.message
+                }
+
+                try await NCAPIController.sharedInstance().scheduleMessage(self.textView.text, inRoom: self.room.token, sendAt: timestamp, replyTo: replyToMessage?.messageId, threadId: self.thread?.threadId, forAccount: self.account)
+                NotificationPresenter.shared().present(text: NSLocalizedString("Message successfully scheduled", comment: ""), dismissAfterDelay: 5.0, includedStyle: .success)
+
+                self.clearInputAfterSend()
+                NCRoomsManager.sharedInstance().updateRoom(self.room.token, withCompletionBlock: nil)
+            } catch {
+                print(error)
+                NotificationPresenter.shared().present(text: NSLocalizedString("Message scheduling failed", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
+            }
+        }
+    }
+
+    private func clearInputAfterSend() {
         self.mentionsDict.removeAll()
         self.replyMessageView?.dismiss()
         super.didPressRightButton(self)
@@ -753,7 +793,12 @@ import SwiftUI
             self.sendCurrentMessage(silently: false)
             super.didPressRightButton(sender)
         case sendButtonTagVoice:
-            self.showVoiceMessageRecordHint()
+            if self.room.hasScheduledMessages {
+                let scheduledViewController = ScheduledMessagesChatViewController(forRoom: self.room, withAccount: self.account)!
+                self.presentWithNavigation(scheduledViewController, animated: true)
+            } else {
+                self.showVoiceMessageRecordHint()
+            }
         default:
             break
         }
@@ -779,11 +824,23 @@ import SwiftUI
             self.voiceMessageLongPressGesture = nil
         }
 
-        let silentSendAction = UIAction(title: NSLocalizedString("Send without notification", comment: ""), image: UIImage(systemName: "bell.slash")) { [unowned self] _ in
-            self.sendCurrentMessage(silently: true)
+        var actions: [UIMenuElement] = []
+
+        if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityScheduleMessages, forAccountId: self.account.accountId) {
+            actions.append(UIAction(title: NSLocalizedString("Send later without notification", comment: ""), image: UIImage(named: "custom.paperplane.badge.clock")) { [unowned self] _ in
+                self.sendCurrentMessageLater(silently: true)
+            })
+
+            actions.append(UIAction(title: NSLocalizedString("Send later", comment: ""), image: UIImage(named: "custom.paperplane.badge.clock")) { [unowned self] _ in
+                self.sendCurrentMessageLater(silently: false)
+            })
         }
 
-        self.rightButton.menu = UIMenu(children: [silentSendAction])
+        actions.append(UIAction(title: NSLocalizedString("Send without notification", comment: ""), image: UIImage(systemName: "bell.slash")) { [unowned self] _ in
+            self.sendCurrentMessage(silently: true)
+        })
+
+        self.rightButton.menu = UIMenu(children: actions)
     }
 
     func addMenuToLeftButton() {
@@ -1738,6 +1795,7 @@ import SwiftUI
         self.recordCancelled = true
         self.stopRecordingVoiceMessage()
         handleCollapseVoiceRecording()
+        self.showVoiceMessageRecordButton()
     }
 
     func handleSend() {
@@ -1842,7 +1900,9 @@ import SwiftUI
     }
 
     func shareVoiceMessage() {
+        self.showVoiceMessageRecordButton()
         guard let recorder = self.recorder else { return }
+
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "yyyy-MM-dd HH-mm-ss"
         let dateString = dateFormatter.string(from: Date())
@@ -1960,6 +2020,8 @@ import SwiftUI
         if flag, recorder == self.recorder, !self.recordCancelled {
             self.shareVoiceMessage()
         }
+
+        self.showVoiceMessageRecordButton()
     }
 
     // MARK: - Voice Messages Transcribe
@@ -2129,6 +2191,7 @@ import SwiftUI
             self.longPressStartingPoint = point
             self.cancelHintLabelInitialPositionX = voiceMessageRecordingView?.slideToCancelHintLabel?.frame.origin.x
             self.voiceRecordingLockButton.alpha = 1
+            self.rightButton.setImage(UIImage(systemName: "mic"), for: .normal)
         } else if gestureRecognizer.state == .ended {
             self.shouldLockInterfaceOrientation(lock: false)
             self.resetVoiceRecordingLockButton()

--- a/NextcloudTalk/Chat/Chat views/NCChatTitleView.h
+++ b/NextcloudTalk/Chat/Chat views/NCChatTitleView.h
@@ -27,6 +27,7 @@
 @property (strong, nonatomic) UILongPressGestureRecognizer *longPressGestureRecognizer;
 
 - (void)updateForRoom:(NCRoom *)room;
+- (void)updateForScheduledMessagesIn:(NCRoom *)room;
 - (void)updateForThread:(NCThread *)thread;
 
 @end

--- a/NextcloudTalk/Chat/Chat views/NCChatTitleView.m
+++ b/NextcloudTalk/Chat/Chat views/NCChatTitleView.m
@@ -111,6 +111,11 @@
     [self setTitle:room.displayName withSubtitle:subtitle];
 }
 
+- (void)updateForScheduledMessagesIn:(NCRoom *)room
+{
+    [self setTitle:NSLocalizedString(@"Scheduled messages", nil) withSubtitle:room.displayName];
+}
+
 - (void)updateForThread:(NCThread *)thread
 {
     // Set thread image

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1309,6 +1309,10 @@ import SwiftUI
         }
 
         self.checkRetention()
+
+        // Update right button after receiving a room update (for scheduled messages)
+        // TODO: Button update should be a separate method
+        _ = self.canPressRightButton()
     }
 
     func didJoinRoom(notification: Notification) {

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -60,10 +60,6 @@ import SwiftUI
 
     private var lobbyCheckTimer: Timer?
 
-    public var isThreadViewController: Bool {
-        return thread != nil
-    }
-
     // MARK: - Thread notification levels
 
     enum NotificationLevelOption: Int, CaseIterable {
@@ -510,15 +506,6 @@ import SwiftUI
     }
 
     private var messageExpirationTimer: Timer?
-
-    override func setTitleView() {
-        super.setTitleView()
-
-        if isThreadViewController {
-            self.titleView?.update(for: thread)
-            self.titleView?.longPressGestureRecognizer.isEnabled = false
-        }
-    }
 
     public override init?(forRoom room: NCRoom, withAccount account: TalkAccount) {
         self.chatController = NCChatController(for: room)

--- a/NextcloudTalk/Chat/ContextChatViewController.swift
+++ b/NextcloudTalk/Chat/ContextChatViewController.swift
@@ -10,10 +10,6 @@ import Foundation
     override func setTitleView() {
         super.setTitleView()
 
-        if thread != nil {
-            self.titleView?.update(for: thread)
-        }
-
         self.titleView?.longPressGestureRecognizer.isEnabled = false
     }
 

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -22,6 +22,10 @@ import UIKit
     internal var contentView: UIView?
     internal var selectedAutocompletionRow: IndexPath?
 
+    public var isThreadViewController: Bool {
+        return thread != nil
+    }
+
     public init?(forRoom room: NCRoom, withAccount account: TalkAccount, tableViewStyle style: UITableView.Style) {
         self.room = room
         self.account = account
@@ -233,7 +237,13 @@ import UIKit
             titleView.showSubtitle = false
         }
 
-        titleView.update(for: self.room)
+        if isThreadViewController {
+            titleView.update(for: thread)
+            titleView.longPressGestureRecognizer.isEnabled = false
+        } else {
+            titleView.update(for: self.room)
+        }
+
         self.titleView = titleView
         self.navigationItem.titleView = titleView
     }

--- a/NextcloudTalk/Chat/ScheduledMessage.swift
+++ b/NextcloudTalk/Chat/ScheduledMessage.swift
@@ -1,0 +1,65 @@
+//
+// SPDX-FileCopyrightText: 2025 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import Foundation
+
+public class ScheduledMessage {
+
+    public var id: String
+    public var actor: TalkActor?
+    public var threadId: Int = 0
+    public var message: String
+    public var messageType: String
+    public var parentMessage: NCChatMessage?
+    public var silent: Bool
+    public var createdAtTimestamp: Int
+    public var sendAtTimestamp: Int
+
+    private var account: TalkAccount
+
+    init?(dictionary dict: [String: Any]?, withAccount account: TalkAccount) {
+        guard let dict else { return nil }
+
+        self.account = account
+
+        self.id = dict["id"] as? String ?? ""
+        self.threadId = dict["threadId"] as? Int ?? 0
+        self.message = dict["message"] as? String ?? ""
+        self.messageType = dict["messageType"] as? String ?? ""
+        self.silent = dict["silent"] as? Bool ?? false
+        self.createdAtTimestamp = dict["createdAt"] as? Int ?? 0
+        self.sendAtTimestamp = dict["sendAt"] as? Int ?? 0
+
+        if let actorId = dict["actorId"] as? String, let actorType = dict["actorType"] as? String {
+            self.actor = TalkActor(actorId: actorId, actorType: actorType)
+        }
+
+        if let parentMessage = dict["parent"] as? [String: Any] {
+            self.parentMessage = NCChatMessage(dictionary: parentMessage, andAccountId: account.accountId)
+        }
+    }
+
+    public func asChatMessage() -> NCChatMessage {
+        let message = NCChatMessage()
+
+        message.messageId = Int(self.id) ?? 0
+        message.actorId = self.account.userId
+        message.actorType = "users"
+        message.actorDisplayName = account.userDisplayName
+        message.accountId = self.account.accountId
+
+        message.timestamp = self.sendAtTimestamp
+        message.message = self.message
+        message.isSilent = self.silent
+
+        if let parentMessage {
+            message.parentId = parentMessage.internalId
+        }
+
+        message.threadId = self.threadId
+
+        return message
+    }
+}

--- a/NextcloudTalk/Chat/ScheduledMessagesChatViewController.swift
+++ b/NextcloudTalk/Chat/ScheduledMessagesChatViewController.swift
@@ -1,0 +1,212 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import Foundation
+
+@objcMembers public class ScheduledMessagesChatViewController: BaseChatViewController {
+
+    public override init?(forRoom room: NCRoom, withAccount account: TalkAccount) {
+        super.init(forRoom: room, withAccount: account)
+
+        // No need for an input bar when viewing scheduled messages
+        self.textInputbar.isHidden = true
+
+        // Scroll to bottom manually after hiding the textInputbar, otherwise the
+        // scrollToBottom button might be briefly visible even if not needed
+        self.tableView?.slk_scrollToBottom(animated: false)
+
+        let closeButton = UIBarButtonItem(title: nil, style: .plain, target: nil, action: nil)
+        closeButton.primaryAction = UIAction(title: NSLocalizedString("Close", comment: ""), handler: { [unowned self] _ in
+            self.dismiss(animated: true)
+        })
+        self.navigationItem.rightBarButtonItems = [closeButton]
+
+        Task {
+            await self.showScheduledMessages()
+        }
+    }
+
+    @MainActor required init?(coder decoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func setTitleView() {
+        super.setTitleView()
+
+        self.titleView?.updateForScheduledMessages(in: self.room)
+    }
+
+    public func showScheduledMessages() async {
+        do {
+            let scheduledMessages = try await NCAPIController.sharedInstance().getScheduledMessages(forRoom: self.room.token, forAccount: self.account)
+            self.appendMessages(messages: scheduledMessages.compactMap { $0.asChatMessage() })
+            self.tableView?.reloadData()
+            self.tableView?.slk_scrollToBottom(animated: false)
+        } catch {
+
+        }
+
+        self.chatBackgroundView.loadingView.stopAnimating()
+        self.chatBackgroundView.loadingView.isHidden = true
+    }
+
+    // MARK: - Editing support
+
+    public override func didCommitTextEditing(_ sender: Any) {
+        guard let editingMessage else { return }
+
+        let messageParametersJSONString = NCMessageParameter.messageParametersJSONString(from: self.mentionsDict) ?? ""
+        editingMessage.message = self.replaceMentionsDisplayNamesWithMentionsKeysInMessage(message: self.textView.text, parameters: messageParametersJSONString)
+        editingMessage.messageParametersJSONString = messageParametersJSONString
+
+        Task {
+            do {
+                let updatedMessage = try await NCAPIController.sharedInstance().editScheduledMessage(String(editingMessage.messageId), withMessage: editingMessage.sendingMessage, inRoom: self.room.token, sendAt: editingMessage.timestamp, forAccount: self.account)
+                self.updateMessage(withMessageId: editingMessage.messageId, updatedMessage: updatedMessage.asChatMessage())
+                super.didCommitTextEditing(sender)
+                self.setTextInputbarHidden(true, animated: true)
+
+                NotificationPresenter.shared().present(text: NSLocalizedString("Message successfully edited", comment: ""), dismissAfterDelay: 5.0, includedStyle: .success)
+            } catch {
+                print(error)
+                NotificationPresenter.shared().present(text: NSLocalizedString("Message editing failed", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
+            }
+        }
+    }
+
+    public override func didCancelTextEditing(_ sender: Any) {
+        super.didCancelTextEditing(sender)
+        self.setTextInputbarHidden(true, animated: true)
+    }
+
+    // MARK: - Action methods
+
+    func didPressReschedule(for message: NCChatMessage, at indexPath: IndexPath) async {
+        let startingDate = Date(timeIntervalSince1970: TimeInterval(message.timestamp))
+        let minimumDate = Calendar.current.date(byAdding: .minute, value: 15, to: Date())
+
+        self.datePickerTextField.setupDatePicker(startingDate: startingDate, minimumDate: minimumDate)
+
+        let (buttonTapped, selectedDate) = await self.datePickerTextField.getDate()
+        guard buttonTapped == .done, let selectedDate else { return }
+
+        do {
+            let timestamp = Int(selectedDate.timeIntervalSince1970)
+            let updatedMessage = try await NCAPIController.sharedInstance().editScheduledMessage(String(message.messageId), withMessage: message.sendingMessage, inRoom: self.room.token, sendAt: timestamp, forAccount: self.account)
+
+            // TODO: Update message does not support moving to a different section, therefore we remove and insert the updated message
+            self.removeMessage(at: indexPath)
+            self.insertMessages(messages: [updatedMessage.asChatMessage()])
+            self.tableView?.reloadData()
+
+            NotificationPresenter.shared().present(text: NSLocalizedString("Message successfully rescheduled", comment: ""), dismissAfterDelay: 5.0, includedStyle: .success)
+        } catch {
+            print(error)
+            NotificationPresenter.shared().present(text: NSLocalizedString("Message rescheduling failed", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
+        }
+    }
+
+    func didPressSendNow(for message: NCChatMessage, at indexPath: IndexPath) {
+        // "Duplicate" code, since sendChatMessage is not available in BaseChatViewController,
+        // but we can't just move the code to ChatViewController as we then need a second ChatController instance
+        var replyTo = message.parent
+
+        // On thread view, include original thread message as parent message (if there is not parent)
+        if let thread = self.thread, replyTo == nil {
+            replyTo = thread.firstMessage()
+        }
+
+        guard
+            let temporaryMessage = self.createTemporaryMessage(message: message.message, replyTo: replyTo, messageParameters: message.messageParametersJSONString ?? "", silently: message.isSilent, isVoiceMessage: false),
+            let chatController = NCChatController(for: self.room)
+        else { return }
+
+        // Send message
+        chatController.send(temporaryMessage)
+
+        Task {
+            await self.didPressDeleteScheduled(for: message, at: indexPath)
+        }
+
+        self.dismiss(animated: true)
+        NCRoomsManager.sharedInstance().updateRoom(self.room.token, withCompletionBlock: nil)
+    }
+
+    func didPressDeleteScheduled(for message: NCChatMessage, at indexPath: IndexPath) async {
+        do {
+            try await NCAPIController.sharedInstance().deleteScheduledMessage(String(message.messageId), inRoom: self.room.token, forAccount: self.account)
+        } catch {
+            NotificationPresenter.shared().present(text: NSLocalizedString("An error occurred while deleting the message", comment: ""), dismissAfterDelay: 5.0, includedStyle: .error)
+            return
+        }
+
+        self.removeMessage(at: indexPath)
+
+        if self.messages.values.isEmpty {
+            self.dismiss(animated: true)
+            NCRoomsManager.sharedInstance().updateRoom(self.room.token, withCompletionBlock: nil)
+        }
+    }
+
+    // MARK: - TableView overrides
+
+    public override func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
+        guard let message = self.message(for: indexPath) else { return nil }
+
+        var actions: [UIMenuElement] = []
+
+        // Copy option
+        actions.append(UIAction(title: NSLocalizedString("Copy", comment: ""), image: .init(systemName: "doc.on.doc")) { _ in
+            self.didPressCopy(for: message)
+        })
+
+        // Copy Selection
+        actions.append(UIAction(title: NSLocalizedString("Copy message selection", comment: ""), image: .init(systemName: "text.viewfinder")) { _ in
+            self.didPressCopySelection(for: message)
+        })
+
+        // Reschedule option
+        actions.append(UIAction(title: NSLocalizedString("Reschedule", comment: "Reschedule a message that is send later"), image: .init(systemName: "calendar.badge.clock")) { _ in
+            Task {
+                await self.didPressReschedule(for: message, at: indexPath)
+            }
+        })
+
+        // Send now option
+        actions.append(UIAction(title: NSLocalizedString("Send now", comment: "Send a message now"), image: .init(systemName: "paperplane")) { _ in
+            self.didPressSendNow(for: message, at: indexPath)
+        })
+
+        var destructiveMenuActions: [UIMenuElement] = []
+
+        // Edit option
+        destructiveMenuActions.append(UIAction(title: NSLocalizedString("Edit", comment: "Edit a message or room participants"), image: .init(systemName: "pencil")) { _ in
+            self.setTextInputbarHidden(false, animated: true)
+            self.textView.layer.cornerRadius = self.textView.frame.size.height / 2
+            self.didPressEdit(for: message)
+        })
+
+        // Delete option
+        destructiveMenuActions.append(UIAction(title: NSLocalizedString("Delete", comment: ""), image: .init(systemName: "trash"), attributes: .destructive) { _ in
+            Task {
+                await self.didPressDeleteScheduled(for: message, at: indexPath)
+            }
+        })
+
+        if !destructiveMenuActions.isEmpty {
+            actions.append(UIMenu(options: [.displayInline], children: destructiveMenuActions))
+        }
+
+        let menu = UIMenu(children: actions)
+
+        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath) {
+            return nil
+        } actionProvider: { _ in
+            return menu
+        }
+
+        return configuration
+    }
+}

--- a/NextcloudTalk/Database/NCDatabaseManager.h
+++ b/NextcloudTalk/Database/NCDatabaseManager.h
@@ -86,6 +86,7 @@ extern NSString * const kCapabilityImportantConversations;
 extern NSString * const kCapabilitySensitiveConversations;
 extern NSString * const kCapabilityThreads;
 extern NSString * const kCapabilityPinnedMessages;
+extern NSString * const kCapabilityScheduleMessages;
 
 extern NSString * const kNotificationsCapabilityExists;
 extern NSString * const kNotificationsCapabilityTestPush;

--- a/NextcloudTalk/Database/NCDatabaseManager.m
+++ b/NextcloudTalk/Database/NCDatabaseManager.m
@@ -16,7 +16,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 84;
+uint64_t const kTalkDatabaseSchemaVersion           = 85;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";

--- a/NextcloudTalk/Database/NCDatabaseManager.m
+++ b/NextcloudTalk/Database/NCDatabaseManager.m
@@ -87,6 +87,7 @@ NSString * const kCapabilityImportantConversations  = @"important-conversations"
 NSString * const kCapabilitySensitiveConversations  = @"sensitive-conversations";
 NSString * const kCapabilityThreads                 = @"threads";
 NSString * const kCapabilityPinnedMessages          = @"pinned-messages";
+NSString * const kCapabilityScheduleMessages        = @"scheduled-messages";
 
 NSString * const kNotificationsCapabilityExists     = @"exists";
 NSString * const kNotificationsCapabilityTestPush   = @"test-push";

--- a/NextcloudTalk/Images.xcassets/custom.paperplane.badge.clock.symbolset/Contents.json
+++ b/NextcloudTalk/Images.xcassets/custom.paperplane.badge.clock.symbolset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "symbols" : [
+    {
+      "filename" : "custom.paperplane.badge.clock.svg",
+      "idiom" : "universal"
+    }
+  ]
+}

--- a/NextcloudTalk/Images.xcassets/custom.paperplane.badge.clock.symbolset/custom.paperplane.badge.clock.svg
+++ b/NextcloudTalk/Images.xcassets/custom.paperplane.badge.clock.symbolset/custom.paperplane.badge.clock.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--Generator: Apple Native CoreSVG 341-->
+<!DOCTYPE svg
+PUBLIC "-//W3C//DTD SVG 1.1//EN"
+       "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 3300 2200">
+ <!--glyph: "", point size: 100.0, font version: "21.0d4e1", template writer version: "138.0.0"-->
+ <style>.defaults {-sfsymbols-variable-value-mode:color;-sfsymbols-draw-reverses-motion-groups:true}
+
+.monochrome-0 {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-5668a47b21469619 507a2e108bbed8e3 paperplane}
+.monochrome-1 {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.monochrome-2 {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.monochrome-3 {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+
+.multicolor-0:tintColor {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-5668a47b21469619 507a2e108bbed8e3 paperplane}
+.multicolor-1:tintColor {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.multicolor-2:tintColor {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.multicolor-3:white {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+
+.hierarchical-0:secondary {-sfsymbols-motion-group:1;-sfsymbols-layer-tags:-5668a47b21469619 507a2e108bbed8e3 paperplane}
+.hierarchical-1:primary {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.hierarchical-2:primary {-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+.hierarchical-3:primary {opacity:0.0;-sfsymbols-clear-behind:true;-sfsymbols-motion-group:0;-sfsymbols-always-pulses:true;-sfsymbols-layer-tags:-5668a47b21469619 _badge clock}
+
+.SFSymbolsPreviewWireframe {fill:none;opacity:1.0;stroke:black;stroke-width:0.5}
+</style>
+ <g id="Notes">
+  <rect height="2200" id="artboard" style="fill:white;opacity:1" width="3300" x="0" y="0"/>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="292" y2="292"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 322)">Weight/Scale Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 559.711 322)">Ultralight</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 856.422 322)">Thin</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1153.13 322)">Light</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1449.84 322)">Regular</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 1746.56 322)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2043.27 322)">Semibold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2339.98 322)">Bold</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2636.69 322)">Heavy</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:middle;" transform="matrix(1 0 0 1 2933.4 322)">Black</text>
+  <line style="fill:none;stroke:black;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1903" y2="1903"/>
+  <g transform="matrix(0.2 0 0 0.2 263 1933)">
+   <path d="m46.2402 4.15039c21.7773 0 39.4531-17.627 39.4531-39.4043s-17.6758-39.4043-39.4531-39.4043c-21.7285 0-39.4043 17.627-39.4043 39.4043s17.6758 39.4043 39.4043 39.4043Zm0-7.42188c-17.6758 0-31.9336-14.3066-31.9336-31.9824s14.2578-31.9824 31.9336-31.9824 31.9824 14.3066 31.9824 31.9824-14.3066 31.9824-31.9824 31.9824Zm3.61328-17.7734v-28.4668c0-2.24609-1.46484-3.75977-3.71094-3.75977-2.14844 0-3.61328 1.51367-3.61328 3.75977v28.4668c0 2.19727 1.46484 3.71094 3.61328 3.71094 2.24609 0 3.71094-1.51367 3.71094-3.71094Zm-17.8223-10.5957h28.418c2.19727 0 3.71094-1.46484 3.71094-3.61328 0-2.19727-1.51367-3.71094-3.71094-3.71094h-28.418c-2.24609 0-3.75977 1.51367-3.75977 3.71094 0 2.14844 1.51367 3.61328 3.75977 3.61328Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 281.506 1933)">
+   <path d="m58.5449 14.5508c27.4902 0 49.8047-22.3145 49.8047-49.8047s-22.3145-49.8047-49.8047-49.8047-49.8047 22.3145-49.8047 49.8047 22.3145 49.8047 49.8047 49.8047Zm0-8.30078c-22.9492 0-41.5039-18.5547-41.5039-41.5039s18.5547-41.5039 41.5039-41.5039 41.5039 18.5547 41.5039 41.5039-18.5547 41.5039-41.5039 41.5039Zm4.05273-23.0957v-36.9141c0-2.49023-1.70898-4.19922-4.15039-4.19922-2.39258 0-4.05273 1.70898-4.05273 4.19922v36.9141c0 2.44141 1.66016 4.15039 4.05273 4.15039 2.44141 0 4.15039-1.66016 4.15039-4.15039Zm-22.5586-14.4043h36.9629c2.44141 0 4.15039-1.61133 4.15039-4.00391 0-2.44141-1.70898-4.15039-4.15039-4.15039h-36.9629c-2.49023 0-4.15039 1.70898-4.15039 4.15039 0 2.39258 1.66016 4.00391 4.15039 4.00391Z"/>
+  </g>
+  <g transform="matrix(0.2 0 0 0.2 304.924 1933)">
+   <path d="m74.8535 28.3203c35.1074 0 63.623-28.4668 63.623-63.5742s-28.5156-63.623-63.623-63.623-63.5742 28.5156-63.5742 63.623 28.4668 63.5742 63.5742 63.5742Zm0-9.08203c-30.127 0-54.4922-24.3652-54.4922-54.4922s24.3652-54.4922 54.4922-54.4922 54.4922 24.3652 54.4922 54.4922-24.3652 54.4922-54.4922 54.4922Zm4.44336-30.3223v-48.4863c0-2.73438-1.85547-4.63867-4.54102-4.63867-2.58789 0-4.44336 1.9043-4.44336 4.63867v48.4863c0 2.68555 1.85547 4.58984 4.44336 4.58984 2.68555 0 4.54102-1.85547 4.54102-4.58984Zm-28.7109-19.7754h48.4863c2.68555 0 4.58984-1.80664 4.58984-4.39453 0-2.73438-1.85547-4.58984-4.58984-4.58984h-48.4863c-2.73438 0-4.58984 1.85547-4.58984 4.58984 0 2.58789 1.85547 4.39453 4.58984 4.39453Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 263 1953)">Design Variations</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1971)">Symbols are supported in up to nine weights and three scales.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1989)">For optimal layout with text and other symbols, vertically align</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 2007)">symbols with the adjacent text.</text>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="776" x2="776" y1="1919" y2="1933"/>
+  <g transform="matrix(0.2 0 0 0.2 776 1933)">
+   <path d="m16.5527 0.78125c2.58789 0 3.85742-0.976562 4.78516-3.71094l20.5566-57.5195h0.244141l20.6055 57.5195c0.927734 2.73438 2.19727 3.71094 4.73633 3.71094 2.58789 0 4.24805-1.5625 4.24805-4.00391 0-0.830078-0.146484-1.61133-0.537109-2.63672l-22.9004-60.9863c-1.12305-2.97852-3.125-4.49219-6.25-4.49219-3.02734 0-5.07812 1.46484-6.15234 4.44336l-22.9004 61.084c-0.390625 1.02539-0.537109 1.80664-0.537109 2.63672 0 2.44141 1.5625 3.95508 4.10156 3.95508Zm10.2051-20.9473h30.6641c2.00195 0 3.66211-1.66016 3.66211-3.66211 0-2.05078-1.66016-3.66211-3.66211-3.66211h-30.6641c-2.00195 0-3.66211 1.61133-3.66211 3.66211 0 2.00195 1.66016 3.66211 3.66211 3.66211Z"/>
+  </g>
+  <line style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="792.836" x2="792.836" y1="1919" y2="1933"/>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 776 1953)">Margins</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1971)">Leading and trailing margins on the left and right side of each symbol</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 1989)">can be adjusted by modifying the x-location of the margin guidelines.</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2007)">Modifications are automatically applied proportionally to all</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 776 2025)">scales and weights.</text>
+  <g transform="matrix(0.2 0 0 0.2 1289 1933)">
+   <path d="m14.209 13.1348 7.86133 7.86133c4.29688 4.39453 9.32617 4.10156 13.8672-1.02539l60.6934-68.2129-4.88281-4.88281-60.2539 67.6758c-1.80664 1.95312-3.4668 2.44141-5.81055 0.0976562l-5.17578-5.12695c-2.29492-2.29492-1.80664-3.95508 0.195312-5.81055l67.4805-62.1582-4.88281-4.83398-68.0664 62.5977c-4.98047 4.58984-5.32227 9.47266-1.02539 13.8184Zm44.873-97.4609c-2.05078 2.00195-2.24609 4.88281-1.07422 6.78711 1.12305 1.80664 3.4668 3.02734 6.5918 2.24609 5.85938-1.66016 12.5977-2.39258 18.8965 0.927734l-2.68555 7.12891c-1.61133 4.00391-0.732422 6.88477 1.70898 9.42383l10.2539 10.3027c2.34375 2.39258 4.54102 2.44141 7.08008 1.95312l4.44336-0.732422 2.58789 2.53906-0.195312 2.24609c-0.0976562 2.29492 0.537109 4.29688 2.7832 6.49414l3.36914 3.32031c2.29492 2.29492 5.51758 2.49023 7.8125 0.195312l12.9883-13.0371c2.29492-2.34375 2.14844-5.37109-0.195312-7.66602l-3.41797-3.41797c-2.19727-2.19727-4.05273-3.02734-6.34766-2.88086l-2.34375 0.244141-2.44141-2.44141 1.02539-4.6875c0.634766-2.73438-0.244141-4.98047-2.88086-7.61719l-11.2793-11.1816c-12.9395-12.8418-35.5957-11.0352-46.6797-0.146484Zm7.08008 2.05078c8.78906-6.39648 25.9766-5.66406 33.6914 1.95312l12.3047 12.207c1.02539 1.02539 1.2207 1.80664 0.927734 3.32031l-1.46484 6.64062 6.73828 6.68945 4.39453-0.244141c1.12305-0.0488281 1.51367 0.0488281 2.34375 0.878906l2.53906 2.49023-10.8398 10.8398-2.49023-2.49023c-0.830078-0.878906-0.976562-1.2207-0.927734-2.39258l0.292969-4.3457-6.68945-6.73828-6.83594 1.17188c-1.41602 0.292969-2.05078 0.195312-3.17383-0.878906l-8.93555-8.88672c-1.07422-1.02539-1.17188-1.70898-0.488281-3.36914l4.58984-11.4746c-6.10352-6.34766-17.041-7.51953-25.5859-4.58984-0.683594 0.244141-0.927734-0.390625-0.390625-0.78125Z"/>
+  </g>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;font-weight:bold;" transform="matrix(1 0 0 1 1289 1953)">Exporting</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1971)">Symbols should be outlined when exporting to ensure the</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 1289 1989)">design is preserved when submitting to Xcode.</text>
+  <text id="template-version" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1933)">Template v.7.0</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1951)">Requires Xcode 17 or greater</text>
+  <text id="descriptive-name" style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1969)">Generated from </text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;text-anchor:end;" transform="matrix(1 0 0 1 3036 1987)">Typeset at 100.0 points</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 726)">Small</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1156)">Medium</text>
+  <text style="stroke:none;fill:black;font-family:sans-serif;font-size:13;" transform="matrix(1 0 0 1 263 1586)">Large</text>
+ </g>
+ <g id="Guides">
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 696)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="696" y2="696"/>
+  <line id="Capline-S" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="625.541" y2="625.541"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1126)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1126" y2="1126"/>
+  <line id="Capline-M" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1055.54" y2="1055.54"/>
+  <g id="H-reference" style="fill:#27AAE1;stroke:none;" transform="matrix(1 0 0 1 339 1556)">
+   <path d="M0.993654 0L3.63775 0L29.3281-67.1323L30.0303-67.1323L30.0303-70.459L28.1226-70.459ZM11.6885-24.4799L46.9815-24.4799L46.2315-26.7285L12.4385-26.7285ZM55.1196 0L57.7637 0L30.6382-70.459L29.4326-70.459L29.4326-67.1323Z"/>
+  </g>
+  <line id="Baseline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1556" y2="1556"/>
+  <line id="Capline-L" style="fill:none;stroke:#27AAE1;opacity:1;stroke-width:0.5;" x1="263" x2="3036" y1="1485.54" y2="1485.54"/>
+  <line id="right-margin-Black-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="2983.77" x2="2983.77" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Black-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="2883.03" x2="2883.03" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Regular-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="1498.16" x2="1498.16" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Regular-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="1401.53" x2="1401.53" y1="600.785" y2="720.121"/>
+  <line id="right-margin-Ultralight-S" style="fill:none;stroke:#FF3B30;stroke-width:0.5;opacity:1.0;" x1="605.665" x2="605.665" y1="600.785" y2="720.121"/>
+  <line id="left-margin-Ultralight-S" style="fill:none;stroke:#00AEEF;stroke-width:0.5;opacity:1.0;" x1="513.757" x2="513.757" y1="600.785" y2="720.121"/>
+ </g>
+ <g id="Symbols">
+  <g id="Black-S" transform="matrix(1 0 0 1 2883.03 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M56.2012 9.52148C60.0586 9.52148 62.5977 7.03125 64.0137 3.32031L90.1855-65.2832C90.7227-66.6992 90.9668-68.0176 90.9668-69.1895C90.9668-73.0469 88.4277-75.5859 84.5703-75.5859C83.3496-75.5859 82.0312-75.3418 80.6641-74.8047L12.0605-48.6328C8.34961-47.2168 5.85938-44.6777 5.85938-40.8203C5.85938-36.5723 8.74023-34.2773 12.9395-33.0566L40.4297-25.0488L48.3887 2.39258C49.6094 6.5918 51.9531 9.52148 56.2012 9.52148ZM44.873-37.5488L32.7637-41.2598C32.5195-41.3086 32.373-41.5039 32.373-41.748C32.373-41.9434 32.5195-42.1387 32.7148-42.1875L50.0488-49.5117C54.3457-51.2695 58.5938-53.0273 64.8438-55.8594C61.084-52.832 56.6895-49.0723 53.3203-45.8008ZM57.1289-17.041C56.8848-17.041 56.7383-17.1875 56.6895-17.4316L52.9297-29.4922L61.1816-37.9395C64.209-41.0645 68.3594-45.8496 71.2402-49.4629C68.4082-43.2129 66.6504-38.9648 64.8926-34.668L57.5684-17.3828C57.5195-17.1875 57.3242-17.041 57.1289-17.041Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M90.9305 20.2491C105.872 20.2491 118.225 7.84665 118.225-7.09475C118.225-22.0361 105.872-34.3408 90.9305-34.3408C75.9895-34.3408 63.636-22.0361 63.636-7.09475C63.636 7.84665 75.9895 20.2491 90.9305 20.2491Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M90.9305 13.9014C102.405 13.9014 111.878 4.33105 111.878-7.09475C111.878-18.5205 102.405-27.9931 90.9305-27.9931C79.4563-27.9931 69.9837-18.5205 69.9837-7.09475C69.9837 4.33105 79.4563 13.9014 90.9305 13.9014Z"/>
+   <path class="monochrome-3 multicolor-3:white hierarchical-3:primary SFSymbolsPreviewWireframe" d="M81.6536-2.50485C79.3098-2.50485 77.5032-4.31155 77.5032-6.65525C77.5032-8.99905 79.3098-10.8056 81.6536-10.8056L87.1715-10.8056L87.1715-16.9091C87.1715-19.2529 88.9775-21.0595 91.3215-21.0595C93.6655-21.0595 95.4715-19.2529 95.4715-16.9091L95.4715-6.65525C95.4715-4.31155 93.6655-2.50485 91.3215-2.50485L81.6536-2.50485Z"/>
+  </g>
+  <g id="Regular-S" transform="matrix(1 0 0 1 1401.53 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M54.1504 7.4707C57.1777 7.4707 59.2773 4.83398 60.8398 0.878906L85.6445-63.916C86.4258-65.918 86.8652-67.6758 86.8652-69.1406C86.8652-71.8262 85.1562-73.5352 82.4707-73.5352C81.0059-73.5352 79.248-73.0957 77.2949-72.3145L12.0605-47.3145C8.64258-45.9961 5.85938-43.8477 5.85938-40.8203C5.85938-36.9141 8.88672-35.6934 12.7441-34.5215L39.8926-26.5137L47.8027 0.195312C48.9746 4.29688 50.2441 7.4707 54.1504 7.4707ZM41.8457-33.1543L16.1621-41.1133C15.8203-41.2109 15.7227-41.3574 15.7227-41.5039C15.7227-41.6992 15.7715-41.8457 16.1621-41.9922L64.7461-60.3516C68.2129-61.6699 71.5332-63.3789 74.9023-64.9414C71.9727-62.5488 68.5059-59.8145 66.1133-57.4219ZM54.8828-2.29492C54.6875-2.29492 54.5898-2.49023 54.4434-2.83203L46.4844-28.5156L70.752-52.7344C73.1934-55.1758 75.9766-58.6914 78.3203-61.6699C76.7578-58.3008 75-54.9316 73.6816-51.3672L55.3223-2.83203C55.1758-2.44141 55.0781-2.29492 54.8828-2.29492Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M87.1967 18.3448C101.064 18.3448 112.636 6.77245 112.636-7.04585C112.636-20.9618 101.162-32.4365 87.1967-32.4365C73.2807-32.4365 61.8061-20.9618 61.8061-7.04585C61.8061 6.91895 73.2319 18.3448 87.1967 18.3448Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M87.1967 12.6319C97.8897 12.6319 106.924 3.69635 106.924-7.04585C106.924-17.8368 98.0367-26.7236 87.1967-26.7236C76.4057-26.7236 67.519-17.8368 67.519-7.04585C67.519 3.79395 76.4057 12.6319 87.1967 12.6319Z"/>
+   <path class="monochrome-3 multicolor-3:white hierarchical-3:primary SFSymbolsPreviewWireframe" d="M78.2612-4.01855C76.7963-4.01855 75.6733-5.14155 75.6733-6.50875C75.6733-7.92475 76.8452-9.04785 78.2612-9.04785L84.9017-9.04785L84.9017-18.1786C84.9017-19.5458 86.0247-20.6689 87.4407-20.6689C88.8567-20.6689 89.9797-19.5458 89.9797-18.1786L89.9797-6.50875C89.9797-5.09275 88.9057-4.01855 87.4407-4.01855L78.2612-4.01855Z"/>
+  </g>
+  <g id="Ultralight-S" transform="matrix(1 0 0 1 513.757 696)">
+   <path class="monochrome-0 multicolor-0:tintColor hierarchical-0:secondary SFSymbolsPreviewWireframe" d="M51.8345 5.1548C53.4995 5.1548 54.691 4.06202 55.5723 1.65087L81.6939-66.7314C82.021-67.5527 82.1426-68.2207 82.1426-68.8228C82.1426-70.2822 81.2964-71.1284 79.8369-71.1284C79.2349-71.1284 78.5669-71.0069 77.749-70.6797L9.33596-44.5899C6.96242-43.6802 5.85938-42.4854 5.85938-40.8203C5.85938-39.0029 7.02492-38.0547 9.88332-37.2007L39.5747-28.6025L48.2114 1.10351C49.02 3.9336 49.9717 5.1548 51.8345 5.1548ZM40.211-30.7476L10.5767-39.2969C8.64556-39.8486 8.18463-40.2222 8.18463-40.8682C8.18463-41.5176 8.68756-41.9819 10.168-42.5371L76.0985-67.7079C77.204-68.1181 78.3447-68.6464 78.9438-68.8921C78.2392-68.3613 76.3618-66.8984 75.8764-66.413ZM51.8858 2.79098C51.2364 2.79098 50.8662 2.36861 50.3111 0.482884L41.7163-29.1514L77.4272-64.8588C77.8706-65.3022 79.3369-67.1376 79.9551-67.8911C79.664-67.2919 79.1777-66.1933 78.7221-65.1264L53.5513 0.846162C52.9961 2.32662 52.5352 2.79098 51.8858 2.79098Z"/>
+   <path class="monochrome-1 multicolor-1:tintColor hierarchical-1:primary SFSymbolsPreviewWireframe" d="M82.9569 14.3033C94.6448 14.3033 104.31 4.68365 104.31-7.04585C104.31-18.7822 94.6968-28.395 82.9569-28.395C71.266-28.395 61.6077-18.7368 61.6077-7.04585C61.6077 4.69385 71.2625 14.3033 82.9569 14.3033Z"/>
+   <path class="monochrome-2 multicolor-2:tintColor hierarchical-2:primary SFSymbolsPreviewWireframe" d="M82.9569 11.2242C92.9238 11.2242 101.231 3.01515 101.231-7.04585C101.231-17.1103 92.9798-25.3159 82.9569-25.3159C72.9378-25.3159 64.6414-17.0649 64.6414-7.04585C64.6414 3.02205 72.9378 11.2242 82.9569 11.2242Z"/>
+   <path class="monochrome-3 multicolor-3:white hierarchical-3:primary SFSymbolsPreviewWireframe" d="M73.3856-4.42725C72.5565-4.42725 71.8875-5.09615 71.8875-6.00925C71.8875-6.78955 72.5599-7.45845 73.3856-7.45845L81.5248-7.45845L81.5248-19.0868C81.5248-19.9091 82.1937-20.5781 83.0194-20.5781C83.8905-20.5781 84.5594-19.9091 84.5594-19.0868L84.5594-6.00925C84.5594-5.13815 83.8485-4.42725 83.0194-4.42725L73.3856-4.42725Z"/>
+  </g>
+ </g>
+</svg>

--- a/NextcloudTalk/Rooms/NCRoom.h
+++ b/NextcloudTalk/Rooms/NCRoom.h
@@ -149,6 +149,7 @@ extern NSString * const NCRoomObjectTypeExtendedConversation;
 @property (nonatomic, assign) BOOL isSensitive;
 @property (nonatomic, assign) NSInteger lastPinnedId;
 @property (nonatomic, assign) NSInteger hiddenPinnedId;
+@property (nonatomic, assign) BOOL hasScheduledMessages;
 
 + (instancetype _Nullable)roomWithDictionary:(NSDictionary * _Nullable)roomDict andAccountId:(NSString * _Nullable)accountId;
 + (void)updateRoom:(NCRoom * _Nonnull)managedRoom withRoom:(NCRoom * _Nonnull)room;

--- a/NextcloudTalk/Rooms/NCRoom.m
+++ b/NextcloudTalk/Rooms/NCRoom.m
@@ -71,6 +71,7 @@ NSString * const NCRoomObjectTypeExtendedConversation   = @"extended_conversatio
     room.isSensitive = [[roomDict objectForKey:@"isSensitive"] boolValue];
     room.lastPinnedId = [[roomDict objectForKey:@"lastPinnedId"] integerValue];
     room.hiddenPinnedId = [[roomDict objectForKey:@"hiddenPinnedId"] integerValue];
+    room.hasScheduledMessages = [[roomDict objectForKey:@"hasScheduledMessages"] boolValue];
 
     // Local-only field -> update only if there's actually a value
     if ([roomDict objectForKey:@"pendingMessage"] != nil) {
@@ -189,6 +190,7 @@ NSString * const NCRoomObjectTypeExtendedConversation   = @"extended_conversatio
     managedRoom.isSensitive = room.isSensitive;
     managedRoom.lastPinnedId = room.lastPinnedId;
     managedRoom.hiddenPinnedId = room.hiddenPinnedId;
+    managedRoom.hasScheduledMessages = room.hasScheduledMessages;
 }
 
 + (NSString *)primaryKey {

--- a/NextcloudTalk/User Interface/DatePickerTextField.swift
+++ b/NextcloudTalk/User Interface/DatePickerTextField.swift
@@ -115,4 +115,12 @@ struct DatePickerTextFieldWrapper: UIViewRepresentable {
         self.completion = completion
         self.becomeFirstResponder()
     }
+
+    public func getDate() async -> (DatePickerTextFieldButtonTapped, Date?) {
+        return await withCheckedContinuation { continuation in
+            self.getDate { buttonTapped, selectedDate in
+                continuation.resume(returning: (buttonTapped, selectedDate))
+            }
+        }
+    }
 }

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1407,6 +1407,9 @@
 "Message deleted successfully, but Matterbridge is configured and the message might already be distributed to other services" = "Message deleted successfully, but Matterbridge is configured and the message might already be distributed to other services";
 
 /* No comment provided by engineer. */
+"Message editing failed" = "Message editing failed";
+
+/* No comment provided by engineer. */
 "Message expiration" = "Message expiration";
 
 /* Copy 'link' to a message */
@@ -1420,6 +1423,21 @@
 
 /* No comment provided by engineer. */
 "Message preview will be disabled in conversation list and notifications" = "Message preview will be disabled in conversation list and notifications";
+
+/* No comment provided by engineer. */
+"Message rescheduling failed" = "Message rescheduling failed";
+
+/* No comment provided by engineer. */
+"Message scheduling failed" = "Message scheduling failed";
+
+/* No comment provided by engineer. */
+"Message successfully edited" = "Message successfully edited";
+
+/* No comment provided by engineer. */
+"Message successfully rescheduled" = "Message successfully rescheduled";
+
+/* No comment provided by engineer. */
+"Message successfully scheduled" = "Message successfully scheduled";
 
 /* No comment provided by engineer. */
 "Message unpinned" = "Message unpinned";
@@ -1862,6 +1880,9 @@
 /* Name of a repository */
 "Repo" = "Repo";
 
+/* Reschedule a message that is send later */
+"Reschedule" = "Reschedule";
+
 /* No comment provided by engineer. */
 "Resend" = "Resend";
 
@@ -1905,6 +1926,9 @@
 "Schedule a meeting" = "Schedule a meeting";
 
 /* No comment provided by engineer. */
+"Scheduled messages" = "Scheduled messages";
+
+/* No comment provided by engineer. */
 "Screensharing stopped" = "Screensharing stopped";
 
 /* No comment provided by engineer. */
@@ -1932,7 +1956,16 @@
 "Send call notification" = "Send call notification";
 
 /* No comment provided by engineer. */
+"Send later" = "Send later";
+
+/* No comment provided by engineer. */
+"Send later without notification" = "Send later without notification";
+
+/* No comment provided by engineer. */
 "Send message" = "Send message";
+
+/* Send a message now */
+"Send now" = "Send now";
 
 /* No comment provided by engineer. */
 "Send without notification" = "Send without notification";


### PR DESCRIPTION
* Server ref https://github.com/nextcloud/spreed/pull/16297
* API https://github.com/nextcloud/spreed/pull/16297
* UI https://github.com/nextcloud/spreed/pull/16509

To be done in a follow-up:
* Provide presets (tomorrow, next monday, ...). Same as for reminders. In the same process, merge the two menu options.
* Mentions / editing with mentions is lacking backend support ("mention-id"), tbd.
* Think about two right buttons