### PR TITLE
chore: Update test matrix to include stable32 and stable33

### DIFF
--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -15,11 +15,6 @@ on:
       - ShareExtension/**
       - BroadcastUploadExtension/**
 
-    push:
-      branches:
-        - main
-        - stable*
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -108,9 +103,9 @@ jobs:
         # Test with stable23 as well to find regressions in older versions
         configs: [
           { talkbranch: 'stable23', serverbranch: 'stable23', phpversion: '8.0' },
-          { talkbranch: 'stable29', serverbranch: 'stable29', phpversion: '8.3' },
-          { talkbranch: 'stable30', serverbranch: 'stable30', phpversion: '8.3' },
           { talkbranch: 'stable31', serverbranch: 'stable31', phpversion: '8.3' },
+          { talkbranch: 'stable32', serverbranch: 'stable32', phpversion: '8.3' },
+          { talkbranch: 'stable33', serverbranch: 'stable33', phpversion: '8.3' },
           { talkbranch: 'main', serverbranch: 'master', phpversion: '8.3' }
         ]
 


### PR DESCRIPTION
The `push` key was wrongly indented, so it never worked anyway. I also see hardly a reason to keep it, so remove it.
Also we never added stable32 it seems, so update the matrix to match the correct versions.