### PR TITLE
fix(chat): Preserve message text when sharing media from picker

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -1599,6 +1599,9 @@ import SwiftUI
 
         guard let (shareConfirmationVC, navigationController) = self.createShareConfirmationViewController() else { return }
 
+        shareConfirmationVC.setChatMessage(self.textView.text)
+        self.setChatMessage("")
+
         picker.dismiss(animated: true) {
             self.present(navigationController, animated: true) {
                 for result in results {
@@ -1644,6 +1647,9 @@ import SwiftUI
               let mediaType = info[.mediaType] as? String
         else { return }
 
+        shareConfirmationVC.setChatMessage(self.textView.text)
+        self.setChatMessage("")
+
         if mediaType == "public.image" {
             guard let image = info[.originalImage] as? UIImage else { return }
 
@@ -1678,6 +1684,9 @@ import SwiftUI
 
     public func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentsAt urls: [URL]) {
         guard let (shareConfirmationVC, navigationController) = self.createShareConfirmationViewController() else { return }
+
+        shareConfirmationVC.setChatMessage(self.textView.text)
+        self.setChatMessage("")
 
         self.present(navigationController, animated: true) {
             for url in urls {


### PR DESCRIPTION
## Summary

- Fixes an issue where text typed in the chat input field was lost when selecting media to share
- The text is now transferred to the ShareConfirmationViewController as the media caption
- Matches the existing behavior for pasted media content

## Problem

When a user had already typed text in the chat input field and then selected an image, video, or document to share via the picker, the text was being wiped/cleared instead of being used as the caption for the shared media.

## Solution

Added calls to `setChatMessage()` in the picker delegate methods to transfer the existing text to the ShareConfirmationViewController before clearing the main input field. This mirrors the implementation that already exists in `didPasteMediaContent()`.

**Affected picker delegates:**
- `PHPickerViewControllerDelegate` (photo library)
- `UIImagePickerControllerDelegate` (camera)
- `UIDocumentPickerViewControllerDelegate` (files)

If the user cancels the share, the text is restored to the chat input (this was already implemented in `shareConfirmationViewControllerDidCancel`).

## Test plan

- [ ] Type some text in the chat input
- [ ] Tap the attachment button and select "Photo Library"
- [ ] Select an image
- [ ] Verify the text appears in the caption field of the share confirmation view
- [ ] Cancel the share and verify the text is restored to the chat input
- [ ] Repeat for camera and file picker