### PR TITLE
chore: Handle E2EE calling setup

### DIFF
--- a/NextcloudTalk/Calls/CallKitManager.m
+++ b/NextcloudTalk/Calls/CallKitManager.m
@@ -459,6 +459,11 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 
 - (void)startCall:(NSString *)token withVideoEnabled:(BOOL)videoEnabled andDisplayName:(NSString *)displayName asInitiator:(BOOL)initiator silently:(BOOL)silently recordingConsent:(BOOL)recordingConsent withAccountId:(NSString *)accountId
 {
+    if ([[NCSettingsController sharedInstance] isEndToEndEncryptedCallingEnabledForAccount:accountId]) {
+        [self reportAndCancelIncomingCall:token forAccountId:accountId withLocalNotificationType:kNCLocalNotificationTypeEndToEndEncryptionUnsupported];
+        return;
+    }
+
     if (![CallKitManager isCallKitAvailable]) {
         NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:token forKey:@"roomToken"];
         [userInfo setValue:@(videoEnabled) forKey:@"isVideoEnabled"];

--- a/NextcloudTalk/Calls/CallKitManager.m
+++ b/NextcloudTalk/Calls/CallKitManager.m
@@ -153,7 +153,12 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 
     BOOL ongoingCalls = _calls.count > 0;
     TalkAccount *activeAccount = [[NCDatabaseManager sharedInstance] activeAccount];
-    
+
+    if ([[NCSettingsController sharedInstance] isEndToEndEncryptedCallingEnabledForAccount:activeAccount.accountId]) {
+        [self reportAndCancelIncomingCall:token forAccountId:accountId withLocalNotificationType:kNCLocalNotificationTypeEndToEndEncryptionUnsupported];
+        return;
+    }
+
     // If the app is not active (e.g. in background) and there is an open chat
     BOOL isAppActive = [[UIApplication sharedApplication] applicationState] == UIApplicationStateActive;
     ChatViewController *chatViewController = [[NCRoomsManager shared] chatViewController];
@@ -162,12 +167,12 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
         [chatViewController leaveChat];
         [[NCUserInterfaceController sharedInstance] presentConversationsList];
     }
-    
+
     // If the incoming call is from a different account
     if (![activeAccount.accountId isEqualToString:accountId]) {
         // If there is an ongoing call then show a local notification
         if (ongoingCalls) {
-            [self reportAndCancelIncomingCall:token withDisplayName:displayName forAccountId:accountId];
+            [self reportAndCancelIncomingCall:token forAccountId:accountId withLocalNotificationType:kNCLocalNotificationTypeCancelledCall];
             return;
         // Change accounts if there are no ongoing calls
         } else {
@@ -211,7 +216,7 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
     }];
 }
 
-- (void)reportAndCancelIncomingCall:(NSString *)token withDisplayName:(NSString *)displayName forAccountId:(NSString *)accountId
+- (void)reportAndCancelIncomingCall:(NSString *)token forAccountId:(NSString *)accountId withLocalNotificationType:(NCLocalNotificationType)notificationType
 {
     CXCallUpdate *update = [self defaultCallUpdate];
     NSUUID *callUUID = [NSUUID new];
@@ -225,9 +230,9 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
         if (!error) {
             [weakSelf.calls setObject:call forKey:callUUID];
             NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:call.token forKey:@"roomToken"];
-            [userInfo setValue:@(kNCLocalNotificationTypeCancelledCall) forKey:@"localNotificationType"];
+            [userInfo setValue:@(notificationType) forKey:@"localNotificationType"];
             [userInfo setObject:call.accountId forKey:@"accountId"];
-            [[NCNotificationController sharedInstance] showLocalNotification:kNCLocalNotificationTypeCancelledCall withUserInfo:userInfo];
+            [[NCNotificationController sharedInstance] showLocalNotification:notificationType withUserInfo:userInfo];
             [weakSelf endCallWithUUID:callUUID];
         } else {
             NSLog(@"Provider could not present incoming call view.");

--- a/NextcloudTalk/Calls/CallKitManager.m
+++ b/NextcloudTalk/Calls/CallKitManager.m
@@ -460,7 +460,10 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
 - (void)startCall:(NSString *)token withVideoEnabled:(BOOL)videoEnabled andDisplayName:(NSString *)displayName asInitiator:(BOOL)initiator silently:(BOOL)silently recordingConsent:(BOOL)recordingConsent withAccountId:(NSString *)accountId
 {
     if ([[NCSettingsController sharedInstance] isEndToEndEncryptedCallingEnabledForAccount:accountId]) {
-        [self reportAndCancelIncomingCall:token forAccountId:accountId withLocalNotificationType:kNCLocalNotificationTypeEndToEndEncryptionUnsupported];
+        NSMutableDictionary *userInfo = [NSMutableDictionary dictionaryWithObject:token forKey:@"roomToken"];
+        [userInfo setValue:@(kNCLocalNotificationTypeEndToEndEncryptionUnsupported) forKey:@"localNotificationType"];
+        [userInfo setObject:accountId forKey:@"accountId"];
+        [[NCNotificationController sharedInstance] showLocalNotification:kNCLocalNotificationTypeEndToEndEncryptionUnsupported withUserInfo:userInfo];
         return;
     }
 

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -189,6 +189,17 @@ import SwiftUI
     }
 
     func startCall(withVideo video: Bool, silently: Bool, button: BarButtonItemWithActivity) {
+        if NCSettingsController.sharedInstance().isEndToEndEncryptedCallingEnabled(forAccount: self.account.accountId) {
+            let alert = UIAlertController(title: NSLocalizedString("Unsupported", comment: "Calling is not supported"),
+                                          message: NSLocalizedString("Calling is currently not supported because end-to-end-encryption is enabled on the server", comment: ""),
+                                          preferredStyle: .alert)
+
+            alert.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: ""), style: .default))
+            self.present(alert, animated: true)
+
+            return
+        }
+
         button.showIndicator()
         if self.room.recordingConsent {
             let alert = UIAlertController(title: "⚠️" + NSLocalizedString("The call might be recorded", comment: ""),

--- a/NextcloudTalk/Database/NCDatabaseManager.m
+++ b/NextcloudTalk/Database/NCDatabaseManager.m
@@ -16,7 +16,7 @@
 
 NSString *const kTalkDatabaseFolder                 = @"Library/Application Support/Talk";
 NSString *const kTalkDatabaseFileName               = @"talk.realm";
-uint64_t const kTalkDatabaseSchemaVersion           = 85;
+uint64_t const kTalkDatabaseSchemaVersion           = 86;
 
 NSString * const kCapabilitySystemMessages          = @"system-messages";
 NSString * const kCapabilityNotificationLevels      = @"notification-levels";
@@ -465,6 +465,12 @@ NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCData
         capabilities.callReactions = [callConfig objectForKey:@"supported-reactions"];
     } else {
         capabilities.callReactions = (RLMArray<RLMString> *)@[];
+    }
+
+    if ([callConfigKeys containsObject:@"end-to-end-encryption"]) {
+        capabilities.e2eeCallsEnabled = [[callConfig objectForKey:@"end-to-end-encryption"] boolValue];
+    } else {
+        capabilities.e2eeCallsEnabled = NO;
     }
 
     // Conversations capabilities

--- a/NextcloudTalk/Database/TalkCapabilities.h
+++ b/NextcloudTalk/Database/TalkCapabilities.h
@@ -33,6 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property NSInteger retentionEvent;
 @property NSInteger retentionPhone;
 @property NSInteger retentionInstantMeetings;
+@property BOOL e2eeCallsEnabled;
 
 @end
 

--- a/NextcloudTalk/NCTypes.h
+++ b/NextcloudTalk/NCTypes.h
@@ -156,7 +156,8 @@ typedef NS_ENUM(NSInteger, NCLocalNotificationType) {
     kNCLocalNotificationTypeChatNotification,
     kNCLocalNotificationTypeFailedToShareRecording,
     kNCLocalNotificationTypeFailedToAcceptInvitation,
-    kNCLocalNotificationTypeRecordingConsentRequired
+    kNCLocalNotificationTypeRecordingConsentRequired,
+    kNCLocalNotificationTypeEndToEndEncryptionUnsupported
 };
 
 typedef NS_ENUM(NSInteger, NCPushNotificationType) {

--- a/NextcloudTalk/Notifications/NCNotificationController.m
+++ b/NextcloudTalk/Notifications/NCNotificationController.m
@@ -148,6 +148,14 @@ NSString * const NCNotificationActionFederationInvitationReject     = @"REJECT_F
         }
             break;
 
+        case kNCLocalNotificationTypeEndToEndEncryptionUnsupported:
+        {
+            NSString *endToEndEncryptionUnsupported = NSLocalizedString(@"Calling is currently not supported because end-to-end-encryption is enabled on the server", nil);
+            content.body = [NSString stringWithFormat:@"⚠️ %@", endToEndEncryptionUnsupported];
+            content.userInfo = userInfo;
+        }
+            break;
+
         default:
             break;
     }

--- a/NextcloudTalk/Settings/NCSettingsController.swift
+++ b/NextcloudTalk/Settings/NCSettingsController.swift
@@ -1,0 +1,14 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import Foundation
+
+@objc public extension NCSettingsController {
+
+    func isEndToEndEncryptedCallingEnabled(forAccount accountId: String) -> Bool {
+        return NCDatabaseManager.sharedInstance().serverCapabilities(forAccountId: accountId)?.e2eeCallsEnabled ?? false
+    }
+
+}

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -506,6 +506,9 @@
 "Call without notification" = "Call without notification";
 
 /* No comment provided by engineer. */
+"Calling is currently not supported because end-to-end-encryption is enabled on the server" = "Calling is currently not supported because end-to-end-encryption is enabled on the server";
+
+/* No comment provided by engineer. */
 "CallKit supported?" = "CallKit supported?";
 
 /* No comment provided by engineer. */
@@ -2350,6 +2353,9 @@
 
 /* No comment provided by engineer. */
 "Unread messages" = "Unread messages";
+
+/* Calling is not supported */
+"Unsupported" = "Unsupported";
 
 /* No comment provided by engineer. */
 "Update" = "Update";


### PR DESCRIPTION
We should be aware of E2EE calling, so we don't need to block the whole app, just the calling part.

- [x] Need to handle CallKit calls as well

<img width="250" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-01-26 at 23 10 20" src="https://github.com/user-attachments/assets/57e3063e-caa6-4067-a0c8-9f192f3f6fd9" />

CallKit:
<img width="250" height="259" alt="Bildschirmfoto 2026-01-30 um 18 10 52" src="https://github.com/user-attachments/assets/71055837-15f2-4e0b-9f5e-a7f6db48f24b" />

