### PR TITLE
Fix overlay scrolling (e.g. pinned message)

### DIFF
--- a/NextcloudTalk/Chat/Chat views/MessageBodyTextView.m
+++ b/NextcloudTalk/Chat/Chat views/MessageBodyTextView.m
@@ -80,6 +80,11 @@
 // https://stackoverflow.com/a/44878203
 - (BOOL)pointInside:(CGPoint)point withEvent:(UIEvent *)event
 {
+    // In case scrolling is enabled, we need to allow touch recognition, as we can't scroll otherwise
+    if (self.scrollEnabled) {
+        return true;
+    }
+
     UITextPosition *position = [self closestPositionToPoint:point];
     if (!position) {return NO;}
     UITextRange *range = [self.tokenizer rangeEnclosingPosition:position withGranularity:UITextGranularityCharacter inDirection:(UITextDirection)UITextLayoutDirectionLeft];

--- a/NextcloudTalk/Chat/NCChatMessage.m
+++ b/NextcloudTalk/Chat/NCChatMessage.m
@@ -492,7 +492,7 @@ NSString * const kSharedItemTypePinned      = @"pinned";
         return nil;
     }
 
-    if (!_isMarkdownMessage) {
+    if (!self.isMarkdownMessage) {
         return parsedMessage;
     }
 


### PR DESCRIPTION
Scrolling is prevented due to our `pointInside` method. It worked in my tests, because I always dragged a link to scroll, which passes the `pointInside` check.