### PR TITLE
fix: Reset room password in room creation view when allow guest switch is disabled

### DIFF
--- a/NextcloudTalk/Rooms/RoomCreationTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomCreationTableViewController.swift
@@ -192,6 +192,9 @@ enum RoomVisibilityOption: Int {
     func allowGuestValueChanged(_ sender: Any?) {
         if let optionSwitch = sender as? UISwitch {
             self.isPublic = optionSwitch.isOn
+            if !optionSwitch.isOn {
+                self.roomPassword = ""
+            }
             self.updateVisibilitySection()
         }
     }


### PR DESCRIPTION
Steps to reproduce the issue:

- create a conversation
- enable "allow guests to join this conversation via link"
- set a password
- disable "allow guests to join this conversation via link"
- create conversation -> 400 bad request error

Before this PR, the room password was not resetted so the app tried to set a password to a newly created group conversation (instead to a public conversation) and that's the reason it fails.