### PR TITLE
fix: Prevent re-joining room when leaving chat

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -31,6 +31,7 @@ import SwiftUI
     private var hasStoredHistory = true
     private var hasStopped = false
     private var hasCheckedOutOfOfficeStatus = false
+    private var isLeavingChat = false
 
     private var chatViewPresentedTimestamp = Date().timeIntervalSince1970
     private var generateSummaryFromMessageId: Int?
@@ -622,6 +623,8 @@ import SwiftUI
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
+        if isLeavingChat { return }
 
         self.checkLobbyState()
         self.checkRoomControlsAvailability()
@@ -1254,6 +1257,7 @@ import SwiftUI
     }
 
     public func leaveChat() {
+        self.isLeavingChat = true
         self.hasStopped = true
         self.lobbyCheckTimer?.invalidate()
         self.messageExpirationTimer?.invalidate()

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -60,6 +60,49 @@ final class UIRoomTest: XCTestCase {
         XCTAssert(conversationTextField.waitForNonExistence(timeout: TestConstants.timeoutShort))
     }
 
+    func testJoinAndLeaveConversation() {
+        let app = launchAndLogin()
+        let openConversationName = "OpenConversationTest"
+
+        waitForReady(object: app.buttons["Create or join a conversation"]).tap()
+        waitForReady(object: app.tables.cells.staticTexts["Join open conversations"]).tap()
+        waitForReady(object: app.tables.cells.staticTexts[openConversationName]).tap()
+
+        let chatNavBar = app.navigationBars["NextcloudTalk.ChatView"]
+
+        // Wait for navigationBar
+        XCTAssert(chatNavBar.waitForExistence(timeout: TestConstants.timeoutLong))
+
+        // Wait for titleView
+        let chatTitleView = chatNavBar.textViews[openConversationName]
+        XCTAssert(chatTitleView.waitForExistence(timeout: TestConstants.timeoutShort))
+
+        // Wait until we joined the room and the call buttons get active
+        let callOptionsButton = chatNavBar.buttons["Call options"]
+        waitForReady(object: callOptionsButton)
+
+        // Open conversation settings
+        chatTitleView.tap()
+
+        // Leave open conversation
+        let leaveButton = app.buttons["Leave conversation"]
+        app.scrollTo(leaveButton)
+        leaveButton.tap()
+        waitForReady(object: app.buttons["Leave"]).tap()
+        waitForReady(object: app.buttons["Create or join a conversation"])
+
+        // Check that the conversation is no longer in conversations list
+        let conversationTextField = app.textFields[openConversationName]
+        let existsInitially = conversationTextField.waitForExistence(timeout: 0.5)
+        if existsInitially {
+            // If it is there initially → it must not be there after the timeout
+            XCTAssertTrue(conversationTextField.waitForNonExistence(timeout: TestConstants.timeoutShort))
+        } else {
+            // If it is not there initially → it must stay like this after timeout
+            XCTAssertFalse(conversationTextField.waitForExistence(timeout: TestConstants.timeoutShort))
+        }
+    }
+
     func testDeallocation() {
         let app = launchAndLogin()
         let newConversationName = "DeAllocTest"

--- a/NextcloudTalkTests/UI/XCUIElementExtensions.swift
+++ b/NextcloudTalkTests/UI/XCUIElementExtensions.swift
@@ -8,23 +8,14 @@ import XCTest
 
 extension XCUIElement {
 
-    // See: https://stackoverflow.com/a/63089781
-    /**
-     * Waits the specified amount of time for the element’s `exists` property to become `false`.
-     *
-     * - Parameter timeout: The amount of time to wait.
-     * - Returns: `false` if the timeout expires without the element coming out of existence.
-     */
-    func waitForNonExistence(timeout: TimeInterval) -> Bool {
+    func scrollTo(_ element: XCUIElement, maxScrolls: Int = 10) {
+        var attempts = 0
 
-        let timeStart = Date().timeIntervalSince1970
-
-        while Date().timeIntervalSince1970 <= (timeStart + timeout) {
-            if !exists { return true }
-
-            usleep(500)
+        while !element.isHittable && attempts < maxScrolls {
+            swipeUp()
+            attempts += 1
         }
 
-        return false
+        XCTAssertTrue(element.isHittable, "Element not found after scrolling.")
     }
 }

--- a/ci-setup-rooms.sh
+++ b/ci-setup-rooms.sh
@@ -43,6 +43,26 @@ curl -u alice:alice "$SERVER_URL/ocs/v2.php/apps/spreed/api/v4/room/$token/parti
     -H 'accept: application/json, text/plain, */*' \
     --data-raw '{"newParticipant":"admin","source":"users"}'
 
+# Setup a listable room so other users can join them
+response=$(curl -u alice:alice "$SERVER_URL/ocs/v2.php/apps/spreed/api/v4/room" \
+    -H "OCS-APIRequest: true" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/plain, */*' \
+    --data-raw '{"roomType":2,"roomName":"OpenConversationTest"}')
+
+echo $response
+
+token=$(echo $response | jq -r .ocs.data.token)
+
+echo $token
+
+curl -u alice:alice "$SERVER_URL/ocs/v2.php/apps/spreed/api/v4/room/$token/listable" \
+    -X 'PUT' \
+    -H "OCS-APIRequest: true" \
+    -H 'content-type: application/json' \
+    -H 'accept: application/json, text/plain, */*' \
+    --data-raw '{"scope":1}'
+
 # Setup a room with react-only permission (can react but cannot chat)
 # Only available when server supports react-permission capability (Talk 24+)
 if has_capability "react-permission"; then


### PR DESCRIPTION
Steps to reproduce:

- Join one open conversation
- Go to "Conversation settings"
- Tap on "Leave conversation"

Without this PR:

User will rejoin the conversation after leaving it, because the chat view will rejoin the conversation (in `viewWillAppear()`) while moving to conversations list.

With this PR:
Prevents any action on chat view's `viewWillAppear()` if `leaveChat()` has been called.