### PR TITLE
fix: Only show pin option for moderators/owners

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -2179,6 +2179,14 @@ import SwiftUI
         return isReactable
     }
 
+    func isMessagePinnable(message: NCChatMessage) -> Bool {
+        var isPinnable = !self.offlineMode
+        isPinnable = isPinnable && self.room.readOnlyState != .readOnly
+        isPinnable = isPinnable && !message.isDeletedMessage && !message.isCommandMessage && !message.sendingFailed && !message.isTemporary
+
+        return isPinnable
+    }
+
     func getSetReminderOptions(for message: NCChatMessage) -> [UIMenuElement] {
         var reminderOptions: [UIMenuElement] = []
 
@@ -2550,7 +2558,7 @@ import SwiftUI
         }
 
         // Pin message
-        if !message.isDeletedMessage, NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityPinnedMessages, for: room) {
+        if self.isMessagePinnable(message: message), room.canPinMessage {
             if message.isPinned {
                 moreMenuActions.append(UIAction(title: NSLocalizedString("Unpin message", comment: ""), image: .init(systemName: "pin.slash")) { _ in
                     Task {

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1832,6 +1832,8 @@ import SwiftUI
         guard let message = notification.userInfo?["historyCleared"] as? NCChatMessage
         else { return }
 
+        self.removePinnedMessageView()
+
         if self.chatController.hasOlderStoredMessagesThanMessageId(message.messageId) {
             self.cleanChat()
             self.chatController.clearHistoryAndResetChatController()

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -2470,7 +2470,7 @@ import SwiftUI
         actions.append(UIMenu(title: NSLocalizedString("Copy", comment: ""), image: .init(systemName: "doc.on.doc"), children: copyMenuActions))
 
         // Remind me later
-        if !message.sendingFailed, !message.isOfflineMessage, NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityRemindMeLater, for: room) {
+        if !message.isTemporary, !message.sendingFailed, !message.isOfflineMessage, NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityRemindMeLater, for: room) {
             let deferredMenuElement = UIDeferredMenuElement.uncached { [weak self] completion in
                 NCAPIController.sharedInstance().getReminderFor(message) { [weak self] response, error in
                     guard let self else { return }

--- a/NextcloudTalk/Rooms/NCRoom.swift
+++ b/NextcloudTalk/Rooms/NCRoom.swift
@@ -363,4 +363,9 @@ import SwiftyAttributes
         return self.canChat
     }
 
+    public var canPinMessage: Bool {
+        // Pinning is also allowed in 1-1-conversations, therefore check isUserOwnerOrModerator, instead of canModerate
+        return self.isUserOwnerOrModerator && NCDatabaseManager.sharedInstance().roomHasTalkCapability(kCapabilityPinnedMessages, for: self)
+    }
+
 }


### PR DESCRIPTION
Currently we show the pinning option for all participants, but we need moderator permission (or owner).