### PR TITLE
fix: Set a name for the RoomsTableViewController

### DIFF
--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -140,7 +140,7 @@ typedef enum RoomsSections {
     [self.tableView setTintColor:[UIColor clearColor]];
 
     // The title is used when long-pressing the back button in a conversation
-    self.navigationItem.backButtonTitle = NSLocalizedString(@"Conversation list", nil);
+    self.navigationItem.backButtonTitle = NSLocalizedString(@"Conversations", nil);
 
     NSDictionary *views = @{@"unreadMentionsButton": _unreadMentionsBottomButton};
     NSDictionary *metrics = @{@"buttonWidth": @(buttonWidth)};

--- a/NextcloudTalk/Rooms/RoomsTableViewController.m
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.m
@@ -139,8 +139,8 @@ typedef enum RoomsSections {
     // Set selection color for selected cells
     [self.tableView setTintColor:[UIColor clearColor]];
 
-    // Remove the backButtonTitle, otherwise when we transition to a conversation, "Back" is briefly visible
-    self.navigationItem.backButtonTitle = @"";
+    // The title is used when long-pressing the back button in a conversation
+    self.navigationItem.backButtonTitle = NSLocalizedString(@"Conversation list", nil);
 
     NSDictionary *views = @{@"unreadMentionsButton": _unreadMentionsBottomButton};
     NSDictionary *metrics = @{@"buttonWidth": @(buttonWidth)};

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -617,6 +617,9 @@
 "Conversation details" = "Conversation details";
 
 /* No comment provided by engineer. */
+"Conversation list" = "Conversation list";
+
+/* No comment provided by engineer. */
 "Conversation name" = "Conversation name";
 
 /* No comment provided by engineer. */

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -617,9 +617,6 @@
 "Conversation details" = "Conversation details";
 
 /* No comment provided by engineer. */
-"Conversation list" = "Conversation list";
-
-/* No comment provided by engineer. */
 "Conversation name" = "Conversation name";
 
 /* No comment provided by engineer. */

--- a/NextcloudTalkTests/UI/UICallTest.swift
+++ b/NextcloudTalkTests/UI/UICallTest.swift
@@ -71,7 +71,7 @@ final class UICallTest: XCTestCase {
 
         // Go back to the main view controller
         XCTAssert(callOptionsButton.waitForExistence(timeout: TestConstants.timeoutShort))
-        chatNavBar.buttons["Back"].tap()
+        chatNavBar.buttons["Conversation list"].tap()
 
         // Check if all call view controllers are deallocated
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))

--- a/NextcloudTalkTests/UI/UICallTest.swift
+++ b/NextcloudTalkTests/UI/UICallTest.swift
@@ -71,7 +71,7 @@ final class UICallTest: XCTestCase {
 
         // Go back to the main view controller
         XCTAssert(callOptionsButton.waitForExistence(timeout: TestConstants.timeoutShort))
-        chatNavBar.buttons["Conversation list"].tap()
+        chatNavBar.buttons["Conversations"].tap()
 
         // Check if all call view controllers are deallocated
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -40,7 +40,7 @@ final class UIRoomTest: XCTestCase {
 
         // Go back to conversation list
         app.navigationBars["Conversation settings"].buttons["Back"].tap()
-        chatNavBar.buttons["Back"].tap()
+        chatNavBar.buttons["Conversation list"].tap()
 
         // Check if the conversation appears in the conversation list
         let conversationStaticText = app.tables.cells.staticTexts[newConversationName]
@@ -167,7 +167,7 @@ final class UIRoomTest: XCTestCase {
 
         // Go back to the main view controller
         XCTAssert(callOptionsButton.waitForExistence(timeout: TestConstants.timeoutShort))
-        chatNavBar.buttons["Back"].tap()
+        chatNavBar.buttons["Conversation list"].tap()
 
         // Check if all controllers are deallocated
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -40,7 +40,7 @@ final class UIRoomTest: XCTestCase {
 
         // Go back to conversation list
         app.navigationBars["Conversation settings"].buttons["Back"].tap()
-        chatNavBar.buttons["Conversation list"].tap()
+        chatNavBar.buttons["Conversations"].tap()
 
         // Check if the conversation appears in the conversation list
         let conversationStaticText = app.tables.cells.staticTexts[newConversationName]
@@ -167,7 +167,7 @@ final class UIRoomTest: XCTestCase {
 
         // Go back to the main view controller
         XCTAssert(callOptionsButton.waitForExistence(timeout: TestConstants.timeoutShort))
-        chatNavBar.buttons["Conversation list"].tap()
+        chatNavBar.buttons["Conversations"].tap()
 
         // Check if all controllers are deallocated
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/2403

I was not able to reproduce the original issue on iOS 18 and 26 anymore. So it might be fixed in an earlier iOS version already, given that the change is from 2022 (https://github.com/nextcloud/talk-ios/pull/923)