### PR TITLE
fix: Adjust chat view content inset for overlay views

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -39,6 +39,8 @@ import SwiftUI
 
     private var startCallSilently: Bool = false
 
+    private var currentTopContentInset: CGFloat = 0
+
     private lazy var unreadMessagesSeparator: NCChatMessage = {
         let message = NCChatMessage()
 
@@ -682,6 +684,22 @@ import SwiftUI
         }
 
         self.callOptionsButton.hideIndicator()
+    }
+
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        // Recalculate the top content inset based on the tallest visible overlay.
+        var maxOverlayViewHeight: CGFloat = 0
+        for subview in self.view.subviews {
+            guard subview.alpha > 0, subview is ChatOverlayView || subview is ChatInfoView else { continue }
+            maxOverlayViewHeight = max(maxOverlayViewHeight, subview.frame.height)
+        }
+
+        if currentTopContentInset != maxOverlayViewHeight {
+            currentTopContentInset = maxOverlayViewHeight
+            self.tableView?.contentInset.top = maxOverlayViewHeight
+        }
     }
 
     required init?(coder decoder: NSCoder) {

--- a/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
@@ -148,4 +148,59 @@ final class UnitChatViewControllerTest: TestBaseRealm {
         activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
         XCTAssertEqual(activeAccount.frequentlyUsedEmojis, ["🇫🇮", "🙈", "😵‍💫", "🤷‍♂️"])
     }
+
+    func testContentInsetAdjustsForOverlayViews() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let room = NCRoom()
+        room.token = "overlayToken"
+        room.name = "Overlay Views Test Room"
+        room.accountId = activeAccount.accountId
+
+        try? realm.transaction {
+            realm.add(room)
+        }
+
+        let chatViewController = ChatViewController(forRoom: room, withAccount: activeAccount)!
+
+        // Load the view hierarchy so tableView and viewDidLayoutSubviews work
+        chatViewController.loadViewIfNeeded()
+
+        // Initially no overlay -> inset should be 0
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 0)
+
+        // Add a ChatOverlayView simulating a pinned message
+        let overlayView = ChatOverlayView()
+        overlayView.alpha = 1.0
+        overlayView.frame = CGRect(x: 0, y: 0, width: 320, height: 80)
+        chatViewController.view.addSubview(overlayView)
+
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 80)
+
+        // Add a taller ChatInfoView simulating a retention banner
+        let infoView = ChatInfoView()
+        infoView.alpha = 1.0
+        infoView.frame = CGRect(x: 0, y: 0, width: 320, height: 120)
+        chatViewController.view.addSubview(infoView)
+
+        // Should use the tallest overlay
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 120)
+
+        // Remove the taller view -> should fall back to the shorter overlay
+        infoView.removeFromSuperview()
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 80)
+
+        // Hide the remaining overlay via alpha (same as the fade-out animation)
+        overlayView.alpha = 0
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 0)
+
+        // Remove it fully and confirm inset stays at 0
+        overlayView.removeFromSuperview()
+        chatViewController.viewDidLayoutSubviews()
+        XCTAssertEqual(chatViewController.tableView?.contentInset.top, 0)
+    }
 }


### PR DESCRIPTION
When overlay views (out-of-office, pinned message, or retention) are displayed at the top of the chat, the table view content is partially hidden behind them and section's headers (date labels) are almost always hidden.

![IMG_E0335](https://github.com/user-attachments/assets/96f886b3-da94-434c-a1ce-ec54c6b68faf)

With this PR the tallest visible overlay is calculated and chat's contentInset is adjusted accordingly.

![IMG_E0334](https://github.com/user-attachments/assets/d6a415fc-65d2-4f58-997e-415563b14874)
