### PR TITLE
feat: Add support for sharing .pkpass files (Apple Wallet)

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -5,6 +5,7 @@
 
 import Foundation
 import NextcloudKit
+import PassKit
 import PhotosUI
 import UIKit
 import Realm
@@ -4127,6 +4128,17 @@ import SwiftUI
                 self.present(vlcKitViewController, animated: true)
 
                 return
+            }
+
+            // Use PKAddPassesViewController for Apple Wallet passes
+            if fileExtension == "pkpass" {
+                if let passData = try? Data(contentsOf: URL(fileURLWithPath: fileLocalPath)),
+                   let pass = try? PKPass(data: passData),
+                   let addPassVC = PKAddPassesViewController(pass: pass) {
+                    self.present(addPassVC, animated: true)
+                    self.isPreviewControllerShown = false
+                    return
+                }
             }
 
             let preview = QLPreviewController()

--- a/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
@@ -5,6 +5,7 @@
 
 import UIKit
 import QuickLook
+import PassKit
 
 @objcMembers class RoomSharedItemsTableViewController: UITableViewController,
                                                         NCChatFileControllerDelegate,
@@ -276,6 +277,7 @@ import QuickLook
 
             let fileExtension = URL(fileURLWithPath: fileLocalPath).pathExtension.lowercased()
 
+            // Use VLCKitVideoViewController for file formats unsupported by the native PreviewController
             if VLCKitVideoViewController.supportedFileExtensions.contains(fileExtension) {
                 let vlcViewController = VLCKitVideoViewController(filePath: fileLocalPath)
                 vlcViewController.delegate = self
@@ -284,6 +286,17 @@ import QuickLook
                 self.present(vlcViewController, animated: true)
 
                 return
+            }
+
+            // Use PKAddPassesViewController for Apple Wallet passes
+            if fileExtension == "pkpass" {
+                if let passData = try? Data(contentsOf: URL(fileURLWithPath: fileLocalPath)),
+                   let pass = try? PKPass(data: passData),
+                   let addPassVC = PKAddPassesViewController(pass: pass) {
+                    self.present(addPassVC, animated: true)
+                    self.isPreviewControllerShown = false
+                    return
+                }
             }
 
             let previewController = QLPreviewController()

--- a/ShareExtension/ShareViewController.m
+++ b/ShareExtension/ShareViewController.m
@@ -375,6 +375,22 @@
                                       }];
                 return;
             }
+            // Check if shared pkpass (Apple Wallet)
+            if ([itemProvider hasItemConformingToTypeIdentifier:@"com.apple.pkpass"]) {
+                [itemProvider loadItemForTypeIdentifier:@"com.apple.pkpass"
+                                                options:nil
+                                      completionHandler:^(id<NSSecureCoding>  _Nullable item, NSError * _Null_unspecified error) {
+                                          if ([(NSObject *)item isKindOfClass:[NSData class]]) {
+                                              NSLog(@"Shared Pass = %@", item);
+                                              NSData *passData = (NSData *)item;
+                                              NSString *passFileName = [NSString stringWithFormat:@"Pass_%.f.pkpass", [[NSDate date] timeIntervalSince1970] * 1000];
+                                              NSURL *tempURL = [NSURL fileURLWithPath:[NSTemporaryDirectory() stringByAppendingPathComponent:passFileName]];
+                                              [passData writeToURL:tempURL atomically:YES];
+                                              [shareConfirmationVC.shareItemController addItemWithURLAndName:tempURL withName:passFileName];
+                                          }
+                                      }];
+                return;
+            }
             // Check if shared URL
             if ([itemProvider hasItemConformingToTypeIdentifier:@"public.url"]) {
                 [itemProvider loadItemForTypeIdentifier:@"public.url"


### PR DESCRIPTION
Fix #2432 

- [x] Allow to share .pkpass files using share extension
- [x] Open .pkpass files with PKAddPassesViewContoller 