### PR TITLE
chore: Minimum supported talk version is now 12

### DIFF
--- a/NextcloudTalk/Calls/CallKitManager.m
+++ b/NextcloudTalk/Calls/CallKitManager.m
@@ -435,14 +435,10 @@ NSTimeInterval const kCallKitManagerCheckCallStateEverySeconds  = 5.0;
             return;
         }
 
-        NSInteger callAPIVersion = [ObjcNCAPIVersion getAPIVersionForType:NCAPITypeCall withAccount:account];
         for (NSMutableDictionary *user in peers) {
-            NSString *userId = [user objectForKey:@"userId"];
-            BOOL isUserActorType = YES;
-            if (callAPIVersion >= NCAPIVersionAPIv3) {
-                userId = [user objectForKey:@"actorId"];
-                isUserActorType = [[user objectForKey:@"actorType"] isEqualToString:@"users"];
-            }
+            NSString *userId = [user objectForKey:@"actorId"];
+            BOOL isUserActorType = [[user objectForKey:@"actorType"] isEqualToString:@"users"];;
+
             if ([account.userId isEqualToString:userId] && isUserActorType) {
                 // Account is already in a call (answered the call on a different device) -> no need to keep ringing
                 [self endCallWithUUID:call.uuid];

--- a/NextcloudTalk/Calls/NCCallController.m
+++ b/NextcloudTalk/Calls/NCCallController.m
@@ -1636,17 +1636,10 @@ static NSString * const kNCScreenTrackKind  = @"screen";
         return [_externalSignalingController getParticipantFromSessionId:sessionId].actor;
     }
 
-    NSInteger callAPIVersion = [ObjcNCAPIVersion getAPIVersionForType:NCAPITypeCall withAccount:_account];
-
     for (NSMutableDictionary *user in _peersInCall) {
         NSString *userSessionId = [user objectForKey:@"sessionId"];
         if ([userSessionId isEqualToString:sessionId]) {
-            TalkActor *actor = [[TalkActor alloc] initWithActorId:[user objectForKey:@"userId"] actorType:@"users" actorDisplayName:[user objectForKey:@"displayName"]];
-
-            if (callAPIVersion >= NCAPIVersionAPIv3) {
-                [actor setId:[user objectForKey:@"actorId"]];
-                [actor setType:[user objectForKey:@"actorType"]];
-            }
+            TalkActor *actor = [[TalkActor alloc] initWithActorId:[user objectForKey:@"actorId"] actorType:[user objectForKey:@"actorType"] actorDisplayName:[user objectForKey:@"displayName"]];
 
             return actor;
         }

--- a/NextcloudTalk/Database/NCDatabaseManager.m
+++ b/NextcloudTalk/Database/NCDatabaseManager.m
@@ -94,7 +94,7 @@ NSString * const kCapabilityBotV1                   = @"bots-v1";
 NSString * const kNotificationsCapabilityExists     = @"exists";
 NSString * const kNotificationsCapabilityTestPush   = @"test-push";
 
-NSString * const kMinimumRequiredTalkCapability     = kCapabilityForceMute; // Talk 9.0 is the minimum required version
+NSString * const kMinimumRequiredTalkCapability     = kCapabilityConversationV4; // Talk 12.0 is the minimum required version
 
 NSString * const NCDatabaseManagerPendingFederationInvitationsDidChange = @"NCDatabaseManagerPendingFederationInvitationsDidChange";
 NSString * const NCDatabaseManagerRoomCapabilitiesChangedNotification = @"NCDatabaseManagerRoomCapabilitiesChangedNotification";

--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -748,34 +748,6 @@ class NCAPIController: NSObject, NKCommonDelegate {
         return try await apiSessionManager.deleteOcs(urlString, account: account, parameters: parameters)
     }
 
-    @nonobjc
-    @MainActor
-    @discardableResult
-    public func removeParticipant(_ participant: String, forRoom token: String, forAccount account: TalkAccount) async throws -> OcsResponse {
-        guard let apiSessionManager = self.getAPISessionManager(forAccountId: account.accountId),
-              let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
-        else { throw ApiControllerError.preconditionError }
-
-        let urlString = self.getRequestURL(forConversationEndpoint: "room/\(encodedToken)/participants", forAccount: account)
-        let parameters: [String: String] = ["participant": participant]
-
-        return try await apiSessionManager.deleteOcs(urlString, account: account, parameters: parameters)
-    }
-
-    @nonobjc
-    @MainActor
-    @discardableResult
-    public func removeGuest(_ guest: String, forRoom token: String, forAccount account: TalkAccount) async throws -> OcsResponse {
-        guard let apiSessionManager = self.getAPISessionManager(forAccountId: account.accountId),
-              let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
-        else { throw ApiControllerError.preconditionError }
-
-        let urlString = self.getRequestURL(forConversationEndpoint: "room/\(encodedToken)/guests", forAccount: account)
-        let parameters: [String: String] = ["participant": guest]
-
-        return try await apiSessionManager.deleteOcs(urlString, account: account, parameters: parameters)
-    }
-
     @MainActor
     @discardableResult
     public func removeSelf(fromRoom token: String, forAccount account: TalkAccount) async throws -> OcsResponse {
@@ -795,17 +767,13 @@ class NCAPIController: NSObject, NKCommonDelegate {
     @nonobjc
     @MainActor
     @discardableResult
-    public func changeModerationPermission(forParticipantId participantId: String, withType type: ModeratorPermissionChangeType, inRoom token: String, forAccount account: TalkAccount) async throws -> OcsResponse {
+    public func changeModerationPermission(forAttendeeId attendeeId: Int, withType type: ModeratorPermissionChangeType, inRoom token: String, forAccount account: TalkAccount) async throws -> OcsResponse {
         guard let apiSessionManager = self.getAPISessionManager(forAccountId: account.accountId),
               let encodedToken = token.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed)
         else { throw ApiControllerError.preconditionError }
 
         let urlString = self.getRequestURL(forConversationEndpoint: "room/\(encodedToken)/moderators", forAccount: account)
-        var parameters = ["participant": participantId]
-
-        if NCAPIVersion(forType: .conversation, withAccount: account) >= .APIv3 {
-            parameters = ["attendeeId": participantId]
-        }
+        let parameters = ["attendeeId": attendeeId]
 
         if type == .promoteToModerator {
             return try await apiSessionManager.postOcs(urlString, account: account, parameters: parameters)

--- a/NextcloudTalk/Network/NCAPIVersions.swift
+++ b/NextcloudTalk/Network/NCAPIVersions.swift
@@ -3,14 +3,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
 
-// TODO: Remove when CallKitManager and NCCallController are migrated to swift
-@objcMembers
-public class ObjcNCAPIVersion: NSObject {
-    public static func getAPIVersion(forType type: NCAPIType, withAccount account: TalkAccount) -> Int {
-        return NCAPIVersion(forType: type, withAccount: account).rawValue
-    }
-}
-
 @objc
 public enum NCAPIVersion: Int, Comparable {
 
@@ -21,34 +13,12 @@ public enum NCAPIVersion: Int, Comparable {
 
     init(forType type: NCAPIType, withAccount account: TalkAccount) {
         switch type {
-        case .conversation:
-            if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityConversationV4, forAccountId: account.accountId) {
-                self = .APIv4
-                return
-            }
-
-            if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityChatReadStatus, forAccountId: account.accountId) {
-                self = .APIv3
-                return
-            }
-
-            self = .APIv2
-        case .call:
-            self = NCAPIVersion(forType: .conversation, withAccount: account)
+        case .conversation, .call:
+            self = .APIv4
         case .chat, .reactions, .polls, .breakoutRooms, .federation, .ban, .bots, .recording, .settings, .avatar:
             self = .APIv1
         case .signaling:
-            if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilitySignalingV3, forAccountId: account.accountId) {
-                self = .APIv3
-                return
-            }
-
-            if NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilitySIPSupport, forAccountId: account.accountId) {
-                self = .APIv2
-                return
-            }
-
-            self = .APIv1
+            self = .APIv3
         }
     }
 

--- a/NextcloudTalk/Rooms/NCRoomParticipant.swift
+++ b/NextcloudTalk/Rooms/NCRoomParticipant.swift
@@ -34,20 +34,12 @@ public class NCRoomParticipant: NSObject {
     var statusMessage: String?
     var invitedActorId: String?
 
-    // Deprecated in conversation APIv3
-    var userId: String?
-
-    // Deprecated in conversation APIv4
-    var sessionId: String?
-
     init(dictionary: [String: Any]) {
         self.attendeeId = dictionary["attendeeId"] as? Int ?? 0
         self.actorId = dictionary["actorId"] as? String
         self.displayName = dictionary["displayName"] as? String ?? ""
         self.lastPing = dictionary["lastPing"] as? Int ?? 0
-        self.sessionId = dictionary["sessionId"] as? String
         self.sessionIds = dictionary["sessionIds"] as? [String]
-        self.userId = dictionary["userId"] as? String
 
         if let attendeeTypeRaw = dictionary["actorType"] as? String,
            let attendeeType = AttendeeType(rawValue: attendeeTypeRaw) {
@@ -101,7 +93,7 @@ public class NCRoomParticipant: NSObject {
 
     public var isAppUser: Bool {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        return participantId == activeAccount.userId
+        return actorType == .user && actorId == activeAccount.userId
     }
 
     public var isBridgeBotUser: Bool {
@@ -125,24 +117,7 @@ public class NCRoomParticipant: NSObject {
     }
 
     public var isOffline: Bool {
-        return (sessionId == "0" || sessionId == nil) && (sessionIds ?? []).isEmpty
-    }
-
-    public var participantId: String? {
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        if NCAPIVersion(forType: .conversation, withAccount: activeAccount) >= .APIv3 {
-            return String(attendeeId)
-        }
-
-        if let actorId {
-            return actorId
-        }
-
-        if isGuest {
-            return sessionId
-        }
-
-        return userId
+        return (sessionIds ?? []).isEmpty
     }
 
     public var detailedName: String {

--- a/NextcloudTalk/Rooms/RoomInfo/RoomInfoParticipantsSection.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/RoomInfoParticipantsSection.swift
@@ -150,11 +150,9 @@ struct RoomInfoParticipantsSection: View {
     }
 
     func changeModerationPermission(forParticipant participant: NCRoomParticipant, canModerate: Bool) {
-        guard let participantId = participant.participantId else { return }
-
         Task {
             do {
-                try await NCAPIController.sharedInstance().changeModerationPermission(forParticipantId: participantId, withType: canModerate ? .promoteToModerator : .demoteToParticipant, inRoom: room.token, forAccount: room.account!)
+                try await NCAPIController.sharedInstance().changeModerationPermission(forAttendeeId: participant.attendeeId, withType: canModerate ? .promoteToModerator : .demoteToParticipant, inRoom: room.token, forAccount: room.account!)
                 self.getParticipants()
             } catch {
                 NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Could not change moderation permissions of the participant", comment: ""), withMessage: nil)
@@ -189,28 +187,14 @@ struct RoomInfoParticipantsSection: View {
     func removeParticipant(participant: NCRoomParticipant) async {
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
 
-        if NCAPIVersion(forType: .conversation, withAccount: activeAccount) >= .APIv3 {
-            do {
-                try await NCAPIController.sharedInstance().removeAttendee(participant.attendeeId, forRoom: room.token, forAccount: activeAccount)
-            } catch {
-                NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Could not remove participant", comment: ""), withMessage: nil)
-            }
-
-            self.getParticipants()
-            return
-        }
-
-        guard let participantId = participant.participantId else { return }
-
-        let method = participant.isGuest ? NCAPIController.sharedInstance().removeGuest : NCAPIController.sharedInstance().removeParticipant
-
         do {
-            _ = try await method(participantId, room.token, activeAccount)
+            try await NCAPIController.sharedInstance().removeAttendee(participant.attendeeId, forRoom: room.token, forAccount: activeAccount)
         } catch {
             NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Could not remove participant", comment: ""), withMessage: nil)
         }
 
         self.getParticipants()
+        return
     }
 
     func banParticipant(participant: NCRoomParticipant, withInternalNote internalNote: String) {

--- a/NextcloudTalkTests/Integration/IntegrationRoomTest.swift
+++ b/NextcloudTalkTests/Integration/IntegrationRoomTest.swift
@@ -427,16 +427,19 @@ final class IntegrationRoomTest: TestBase {
         let participantAlice = try XCTUnwrap(participants.first(where: { $0.displayName == "alice" }))
 
         // Promote alice to moderator
-        try await NCAPIController.sharedInstance().changeModerationPermission(forParticipantId: participantAlice.participantId!, withType: .promoteToModerator, inRoom: room.token, forAccount: activeAccount)
+        try await NCAPIController.sharedInstance().changeModerationPermission(forAttendeeId: participantAlice.attendeeId, withType: .promoteToModerator, inRoom: room.token, forAccount: activeAccount)
         participants = try await NCAPIController.sharedInstance().getParticipants(forRoom: room.token, forAccount: activeAccount)
 
         XCTAssertTrue(participants.contains { $0.displayName == "alice" && $0.canModerate })
 
         // Demote alice to participant
-        try await NCAPIController.sharedInstance().changeModerationPermission(forParticipantId: participantAlice.participantId!, withType: .demoteToParticipant, inRoom: room.token, forAccount: activeAccount)
+        try await NCAPIController.sharedInstance().changeModerationPermission(forAttendeeId: participantAlice.attendeeId, withType: .demoteToParticipant, inRoom: room.token, forAccount: activeAccount)
         participants = try await NCAPIController.sharedInstance().getParticipants(forRoom: room.token, forAccount: activeAccount)
 
         XCTAssertTrue(participants.contains { $0.displayName == "alice" && !$0.canModerate })
+
+        // Also check that the test user is in the room and correctly identified as the app user
+        XCTAssertTrue(participants.contains { $0.displayName == "admin" && $0.isAppUser })
 
         // Try to remove admin which should fail, as admin is the last moderator
         do {

--- a/NextcloudTalkTests/Unit/UnitNCRoomParticipantTest.swift
+++ b/NextcloudTalkTests/Unit/UnitNCRoomParticipantTest.swift
@@ -114,7 +114,6 @@ final class UnitNCRoomParticipantTest: TestBaseRealm {
         XCTAssertEqual(participant.status, "busy")
         XCTAssertEqual(participant.statusIcon, "💬")
         XCTAssertEqual(participant.statusMessage, "In a call")
-        XCTAssertNil(participant.userId)
     }
 
 }


### PR DESCRIPTION
* Ref https://github.com/nextcloud/documentation/pull/14504

Conversation API v4 is now the minimum and we can remove older methods / checks.