### PR TITLE
fix: Use plurals for uploading string

### DIFF
--- a/NextcloudTalk/en.lproj/Localizable.stringsdict
+++ b/NextcloudTalk/en.lproj/Localizable.stringsdict
@@ -210,5 +210,21 @@
 			<string>Password needs to be at least %d characters long</string>
 		</dict>
 	</dict>
+	<key>Uploading %ld elements</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@uploadingelements@</string>
+		<key>uploadingelements</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>ld</string>
+			<key>one</key>
+			<string>Uploading %ld element</string>
+			<key>other</key>
+			<string>Uploading %ld elements</string>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -604,11 +604,7 @@ import MBProgressHUD
 
         self.hud = MBProgressHUD.showAdded(to: self.view, animated: true)
         self.hud?.mode = .annularDeterminate
-        self.hud?.label.text = String(format: NSLocalizedString("Uploading %ld elements", comment: ""), self.shareItemController.shareItems.count)
-
-        if self.shareItemController.shareItems.count == 1 {
-            self.hud?.label.text = NSLocalizedString("Uploading 1 element", comment: "")
-        }
+        self.hud?.label.text = String.localizedStringWithFormat(NSLocalizedString("Uploading %ld elements", comment: ""), self.shareItemController.shareItems.count)
 
         self.uploadGroup = DispatchGroup()
         self.uploadErrors = []


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/2495

Needs backporting to remove the old string, since they are referenced in stable23