### PR TITLE
chore: Update localizable

### DIFF
--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -2442,9 +2442,6 @@
 "Uploading %ld elements" = "Uploading %ld elements";
 
 /* No comment provided by engineer. */
-"Uploading 1 element" = "Uploading 1 element";
-
-/* No comment provided by engineer. */
 "User" = "User";
 
 /* No comment provided by engineer. */


### PR DESCRIPTION
* Followup to https://github.com/nextcloud/talk-ios/pull/2498

Since the string is now removed from `stable23`, we can update `main` again.