### PR TITLE
fix: Do not use file names in temporary files uploaded to draft folder

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -4116,7 +4116,9 @@ import Toast
                     failure("Probe conversation attachment folder returned no folder")
                     return
                 }
-                let tempName = UUID().uuidString + "." + (URL(string: fileName)?.pathExtension ?? "")
+                let fileExtension = URL(string: fileName)?.pathExtension ?? ""
+                let extensionSuffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+                let tempName = UUID().uuidString + extensionSuffix
                 let draftPath = "\(draftFolder)/\(tempName)"
                 let fileServerPath = "/\(draftPath)"
 

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -4116,7 +4116,7 @@ import Toast
                     failure("Probe conversation attachment folder returned no folder")
                     return
                 }
-                let tempName = UUID().uuidString + "-" + fileName
+                let tempName = UUID().uuidString + "." + (URL(string: fileName)?.pathExtension ?? "")
                 let draftPath = "\(draftFolder)/\(tempName)"
                 let fileServerPath = "/\(draftPath)"
 

--- a/NextcloudTalk/Chat/NCChatController.m
+++ b/NextcloudTalk/Chat/NCChatController.m
@@ -1026,7 +1026,9 @@ NSString * const NCChatControllerDidReceiveThreadNotFoundNotification           
                     return;
                 }
 
-                NSString *tempName = [NSString stringWithFormat:@"%@.%@", [NSUUID UUID].UUIDString, [NSURL URLWithString:fileName].pathExtension];
+                NSString *fileExtension = [NSURL URLWithString:fileName].pathExtension;
+                NSString *extensionSuffix = fileExtension.length > 0 ? [@"." stringByAppendingString:fileExtension] : @"";
+                NSString *tempName = [[NSUUID UUID].UUIDString stringByAppendingString:extensionSuffix];
                 NSString *draftPath = [NSString stringWithFormat:@"%@/%@", draftFolder, tempName];
                 NSString *serverPath = [NSString stringWithFormat:@"/%@", draftPath];
                 NSString *fileServerURL = [NSString stringWithFormat:@"%@/remote.php/dav/files/%@%@", self->_account.server, self->_account.userId, serverPath];

--- a/NextcloudTalk/Chat/NCChatController.m
+++ b/NextcloudTalk/Chat/NCChatController.m
@@ -1026,7 +1026,7 @@ NSString * const NCChatControllerDidReceiveThreadNotFoundNotification           
                     return;
                 }
 
-                NSString *tempName = [NSString stringWithFormat:@"%@-%@", [NSUUID UUID].UUIDString, fileName];
+                NSString *tempName = [NSString stringWithFormat:@"%@.%@", [NSUUID UUID].UUIDString, [NSURL URLWithString:fileName].pathExtension];
                 NSString *draftPath = [NSString stringWithFormat:@"%@/%@", draftFolder, tempName];
                 NSString *serverPath = [NSString stringWithFormat:@"/%@", draftPath];
                 NSString *fileServerURL = [NSString stringWithFormat:@"%@/remote.php/dav/files/%@%@", self->_account.server, self->_account.userId, serverPath];

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -656,7 +656,9 @@ import MBProgressHUD
             self.uploadGroup.enter()
 
             if let draftFolderPath {
-                let tempName = UUID().uuidString + "." + shareItem.fileURL.pathExtension
+                let fileExtension = shareItem.fileURL.pathExtension
+                let extensionSuffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+                let tempName = UUID().uuidString + extensionSuffix
                 let draftPath = "\(draftFolderPath)/\(tempName)"
                 let fileServerPath = "/\(draftPath)"
 

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -656,7 +656,7 @@ import MBProgressHUD
             self.uploadGroup.enter()
 
             if let draftFolderPath {
-                let tempName = UUID().uuidString + "-" + shareItem.fileName
+                let tempName = UUID().uuidString + "." + shareItem.fileURL.pathExtension
                 let draftPath = "\(draftFolderPath)/\(tempName)"
                 let fileServerPath = "/\(draftPath)"
 


### PR DESCRIPTION
Format: `UUID.ext`

Fix #2502 