### PR TITLE
fix: Always add participants to the participantMap

### DIFF
--- a/NextcloudTalk/WebRTC/NCExternalSignalingController.swift
+++ b/NextcloudTalk/WebRTC/NCExternalSignalingController.swift
@@ -555,6 +555,10 @@ public enum NCExternalSignalingSendMessageStatus {
             for participantDict in joinDict {
                 let participant = SignalingParticipant(withJoinDictionary: participantDict)
 
+                guard let signalingSessionId = participant.signalingSessionId else { continue }
+
+                self.participantsMap[signalingSessionId] = participant
+
                 if !participant.isFederated, participant.userId == self.account.userId {
                     print("App user joined room")
                     continue
@@ -563,14 +567,12 @@ public enum NCExternalSignalingSendMessageStatus {
                 // Only notify if another participant joined the room and not ourselves from a different device
                 print("Participant joined room")
 
-                guard let currentRoom, let signalingSessionId = participant.signalingSessionId
-                else { continue }
+                guard let currentRoom else { continue }
 
                 var userInfo = [String: String]()
                 userInfo["roomToken"] = currentRoom
                 userInfo["sessionId"] = signalingSessionId
 
-                self.participantsMap[signalingSessionId] = participant
                 NotificationCenter.default.post(name: .extSignalingDidReceiveJoinOfParticipant, object: self, userInfo: userInfo)
             }
         } else if eventType == "leave" {


### PR DESCRIPTION
We skipped adding participants to the `participantMap` in external signaling controller, when it's the same user as we are using in web. Regression from swift migration, compare to ObjC code:

https://github.com/nextcloud/talk-ios/blob/84339b590d9e071d85e964d937709aa799a5db44/NextcloudTalk/NCExternalSignalingController.m#L576-L596

How to reproduce:
* Have a group conversation
* Join with Web and iOS, both cameras enabled
* Disable camera on Web

Before:
<img width="250" src="https://github.com/user-attachments/assets/66e256df-843c-4247-a348-5bfea533f601" />

After:
<img width="250" src="https://github.com/user-attachments/assets/755abcc9-4d41-43f3-96ac-9c0bc8b54c13" />
