### PR TITLE
fix: Check account change

### DIFF
--- a/NextcloudTalk/Rooms/NCRoomsManager.swift
+++ b/NextcloudTalk/Rooms/NCRoomsManager.swift
@@ -727,13 +727,13 @@ class NCRoomsManager: NSObject, CallViewControllerDelegate {
     }
 
     private func checkForAccountChange(_ accountId: String?) {
-        guard let accountId else { return }
-
         let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        if activeAccount.accountId == accountId {
-            // Leave chat before changing accounts
-            self.chatViewController?.leaveChat()
-        }
+
+        guard let accountId, accountId != activeAccount.accountId else { return }
+
+        // Leave chat before changing accounts
+        self.chatViewController?.leaveChat()
+
         // Set notification account active
         NCSettingsController.sharedInstance().setActiveAccountWithAccountId(accountId)
     }


### PR DESCRIPTION
* Regression from https://github.com/nextcloud/talk-ios/pull/2362

Compare to 
https://github.com/nextcloud/talk-ios/blob/9dd660b36b5ab9a0dd1abdaec31e36f6bdfba134/NextcloudTalk/Rooms/NCRoomsManager.m#L306-L317

We now left the chat for every push notification, which is not intended to do.