### PR TITLE
fix: Use thread-safe caches in apicontroller

### DIFF
--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -36,10 +36,12 @@ class NCAPIController: NSObject, NKCommonDelegate {
         return NCAPISessionManager(configuration: configuration)
     }()
 
-    private var cookieStorages = [String: HTTPCookieStorage]()
-    private var apiSessionManagers = [String: NCAPISessionManager]()
-    private var longPollingApiSessionManagers = [String: NCAPISessionManager]()
-    private var calDAVSessionManagers = [String: NCCalDAVSessionManager]()
+    // It's possible that we access the dictionary from multiple threads (e.g. in background-fetch)
+    // therefore we use NSCache as it is thread-safe - swift dictionaries are not
+    private var cookieStorages = NSCache<NSString, HTTPCookieStorage>()
+    private var apiSessionManagers = NSCache<NSString, NCAPISessionManager>()
+    private var longPollingApiSessionManagers = NSCache<NSString, NCAPISessionManager>()
+    private var calDAVSessionManagers = NSCache<NSString, NCCalDAVSessionManager>()
 
     enum ApiControllerError: Error {
         case preconditionError
@@ -56,18 +58,18 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
     // Ensure we use the same HTTPCookieStorage object for all session managers
     internal func getHTTPCookieStorage(forAccountId accountId: String) -> HTTPCookieStorage {
-        if let cachedCookieStorage = self.cookieStorages[accountId] {
+        if let cachedCookieStorage = self.cookieStorages.object(forKey: accountId as NSString) {
             return cachedCookieStorage
         }
 
         let newCookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: accountId)
-        self.cookieStorages[accountId] = newCookieStorage
+        self.cookieStorages.setObject(newCookieStorage, forKey: accountId as NSString)
 
         return newCookieStorage
     }
 
-    internal func getAPISessionManager(forAccountId accountId: String) -> NCAPISessionManager? {
-        if let cachedSessionManager = self.apiSessionManagers[accountId] {
+    public func getAPISessionManager(forAccountId accountId: String) -> NCAPISessionManager? {
+        if let cachedSessionManager = self.apiSessionManagers.object(forKey: accountId as NSString) {
             return cachedSessionManager
         }
 
@@ -82,13 +84,13 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
         // As we can run max. 30s in the background, the default timeout should be lower than 30 to avoid being killed by the OS
         apiSessionManager.requestSerializer.timeoutInterval = TimeInterval(25)
-        apiSessionManagers[accountId] = apiSessionManager
+        apiSessionManagers.setObject(apiSessionManager, forKey: accountId as NSString)
 
         return apiSessionManager
     }
 
     internal func getLongPollingAPISessionManager(forAccountId accountId: String) -> NCAPISessionManager? {
-        if let cachedSessionManager = self.longPollingApiSessionManagers[accountId] {
+        if let cachedSessionManager = self.longPollingApiSessionManagers.object(forKey: accountId as NSString) {
             return cachedSessionManager
         }
 
@@ -100,13 +102,13 @@ class NCAPIController: NSObject, NKCommonDelegate {
         longConfiguration.httpCookieStorage = self.getHTTPCookieStorage(forAccountId: accountId)
         let longApiSessionManager = NCAPISessionManager(configuration: longConfiguration)
         longApiSessionManager.requestSerializer.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        longPollingApiSessionManagers[accountId] = longApiSessionManager
+        longPollingApiSessionManagers.setObject(longApiSessionManager, forKey: accountId as NSString)
 
         return longApiSessionManager
     }
 
     internal func getCalDAVSessionManager(forAccountId accountId: String) -> NCCalDAVSessionManager? {
-        if let cachedSessionManager = self.calDAVSessionManagers[accountId] {
+        if let cachedSessionManager = self.calDAVSessionManagers.object(forKey: accountId as NSString) {
             return cachedSessionManager
         }
 
@@ -118,7 +120,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
         calDAVConfiguration.httpCookieStorage = self.getHTTPCookieStorage(forAccountId: accountId)
         let calDAVSessionManager = NCCalDAVSessionManager(configuration: calDAVConfiguration)
         calDAVSessionManager.requestSerializer.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        calDAVSessionManagers[accountId] = calDAVSessionManager
+        calDAVSessionManagers.setObject(calDAVSessionManager, forKey: accountId as NSString)
 
         return calDAVSessionManager
     }
@@ -126,9 +128,9 @@ class NCAPIController: NSObject, NKCommonDelegate {
     public func removeAPISessionManager(forAccount account: TalkAccount) {
         self.authTokenCache.removeValue(forKey: account.accountId)
         self.requestModifierCache.removeValue(forKey: account.accountId)
-        self.apiSessionManagers.removeValue(forKey: account.accountId)
-        self.longPollingApiSessionManagers.removeValue(forKey: account.accountId)
-        self.calDAVSessionManagers.removeValue(forKey: account.accountId)
+        self.apiSessionManagers.removeObject(forKey: account.accountId as NSString)
+        self.longPollingApiSessionManagers.removeObject(forKey: account.accountId as NSString)
+        self.calDAVSessionManagers.removeObject(forKey: account.accountId as NSString)
 
         let cookieStorage = self.getHTTPCookieStorage(forAccountId: account.accountId)
         if let cookies = cookieStorage.cookies {
@@ -136,7 +138,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
                 cookieStorage.deleteCookie(cookie)
             }
         }
-        self.cookieStorages.removeValue(forKey: account.accountId)
+        self.cookieStorages.removeObject(forKey: account.accountId as NSString)
     }
 
     private func authHeader(forAccount account: TalkAccount) -> String? {


### PR DESCRIPTION
We've seen crashes in background fetch lately, e.g.

```
Thread 2 name:
Thread 2 Crashed:
0   libswiftCore.dylib            	0x00000001918a9980 swift_isUniquelyReferenced_nonNull_native + 0 (SwiftObject.mm:1493)
1   NextcloudTalk                 	0x0000000100f83bb0 specialized Dictionary._Variant.isUniquelyReferenced() + 8 (/<compiler-generated>:0)
2   NextcloudTalk                 	0x0000000100f83bb0 specialized Dictionary._Variant.setValue(_:forKey:) + 8 (/<compiler-generated>:0)
3   NextcloudTalk                 	0x0000000100f83bb0 specialized Dictionary.subscript.setter + 8 (NCAPIController.swift:73)
4   NextcloudTalk                 	0x0000000100f83bb0 NCAPIController.getAPISessionManager(forAccountId:) + 596
5   NextcloudTalk                 	0x0000000100f861c8 NCAPIController.getRooms(forAccount:updateStatus:modifiedSince:completionBlock:) + 108 (NCAPIController.swift:291)
6   NextcloudTalk                 	0x000000010101142c NCRoomsManager.updateRooms(updatingUserStatus:onlyLastModified:withCompletion:) + 876 (NCRoomsManager.swift:151)
7   NextcloudTalk                 	0x0000000101010644 NCRoomsManager.updateRoomsAndChats(updatingUserStatus:onlyLastModified:withCompletionBlock:) + 880 (NCRoomsManager.swift:93)
8   NextcloudTalk                 	0x0000000101011048 @objc NCRoomsManager.updateRoomsAndChats(updatingUserStatus:onlyLastModified:withCompletionBlock:) + 132 (/<compiler-generated>:0)
9   NextcloudTalk                 	0x0000000100e72aa0 -[AppDelegate performBackgroundFetchWithCompletionHandler:] + 460 (AppDelegate.m:566)
10  NextcloudTalk                 	0x0000000100e72808 -[AppDelegate handleAppRefresh:] + 120 (AppDelegate.m:506)
11  BackgroundTasks               	0x00000001bf74ddbc __41-[BGTaskScheduler _runTask:registration:]_block_invoke_5 + 228 (BGTaskScheduler.m:662)
```

This boils down to parallel access to the swift dictionaries we used, so use NSCache, which is thread-safe.