### PR TITLE
chore: Fail fast when PHP module cannot be installed // setup-php 2.37.2

### DIFF
--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -155,7 +155,7 @@ jobs:
         submodules: true
 
     - name: Set up php ${{ matrix.configs.phpversion }}
-      uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+      uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
       with:
         php-version: ${{ matrix.configs.phpversion }}
         # https://docs.nextcloud.com/server/stable/admin_manual/installation/source_installation.html#prerequisites-for-manual-installation

--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -165,6 +165,7 @@ jobs:
         # Temporary workaround for missing pcntl_* in PHP 8.3: ini-values: apc.enable_cli=on
         ini-values: apc.enable_cli=on, disable_functions=
       env:
+        fail-fast: true
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Checkout server


### PR DESCRIPTION
There's no need to still try to run our tests if PHP modules are missing.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
