### PR TITLE
Only query teams when circles capability is enabled

### DIFF
--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -1380,6 +1380,12 @@ class NCAPIController: NSObject, NKCommonDelegate {
             return
         }
 
+        guard NCDatabaseManager.sharedInstance().serverHasTalkCapability(kCapabilityCirclesSupport, forAccountId: account.accountId)
+        else {
+            completionBlock([], nil)
+            return
+        }
+
         let urlString = "\(account.server)/ocs/v2.php/apps/circles/probecircles"
 
         apiSessionManager.getOcs(urlString, account: account) { ocsResponse, ocsError in


### PR DESCRIPTION
## Summary

`getUserTeams(forAccount:completionBlock:)` issued a request to the Circles app
endpoint `/ocs/v2.php/apps/circles/probecircles` every time the app reached the
ready state, regardless of whether the Circles/Teams feature was enabled on the
server. This adds a capability guard so the request is only made when the server
advertises `circles-support`. When the capability is absent the method returns an
empty array with no error, which lets the existing caller take its success branch
and clear any stale `teamIds` rather than logging a spurious error.

The guard mirrors the existing `serverHasTalkCapability(kCapabilityCirclesSupport, forAccountId:)`
check already used elsewhere in `NCAPIController.swift`.

## Why this matters

On servers without Circles support, the previous behavior wasted a network
round-trip on every ready-state refresh and produced an error response. Gating the
call on the already-tracked capability avoids the unnecessary request and the
spurious error, as requested in https://github.com/nextcloud/talk-ios/issues/2003.

## Testing

- Circles disabled (no `circles-support` capability): `getUserTeams` returns
  immediately with `[]` and no error; no `probecircles` request is made and the
  account's `teamIds` is cleared via the caller's success branch.
- Circles enabled: behavior is unchanged - the `probecircles` request is still
  issued and team IDs are parsed and stored as before.
- Capability toggled off after previously enabled: the next refresh clears the
  stored `teamIds` instead of leaving stale data.
- Note: this change was reviewed against the existing capability-check precedent
  in the same file rather than via a local Xcode build.

Fixes #2003
