### PR TITLE
fix: handle HTTP 429 during file upload

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -2126,6 +2126,10 @@ import Toast
                     NSLog("User storage quota exceeded")
                     NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Upload failed", comment: ""),
                                                   withMessage: NSLocalizedString("User storage quota exceeded", comment: ""))
+                case 429:
+                    NSLog("Too many requests while uploading")
+                    NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Upload failed", comment: ""),
+                                                  withMessage: NSLocalizedString("Too many requests, please try again later", comment: ""))
                 default:
                     NSLog("Failed upload voice message with error code \(statusCode)")
                     NCUserInterfaceController.sharedInstance().presentAlert(withTitle: NSLocalizedString("Upload failed", comment: ""), withMessage: NSLocalizedString("Unknown error occurred", comment: ""))

--- a/NextcloudTalk/Chat/ChatFileUploader.swift
+++ b/NextcloudTalk/Chat/ChatFileUploader.swift
@@ -73,6 +73,8 @@ import NextcloudKit
                 }
             case 507:
                 completion(507, "User storage quota exceeded")
+            case 429:
+                completion(429, "Too many requests")
             default:
                 completion(NSInteger(error.errorCode), "Failed to upload voice message with error code: \(error.errorCode)" as NSString)
             }

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -2348,6 +2348,9 @@
 /* Remind me tomorrow about that message */
 "Tomorrow" = "Tomorrow";
 
+/* No comment provided by engineer. */
+"Too many requests, please try again later" = "Too many requests, please try again later";
+
 /* TRANSLATORS this is for transcribing a voice message to text */
 "Transcribe" = "Transcribe";
 


### PR DESCRIPTION
## Summary

Handle HTTP 429 (Too Many Requests) distinctly during file uploads so the user gets an actionable message instead of the generic "Unknown error occurred" alert.

- `ChatFileUploader.uploadFile` now propagates a `429` status code (alongside the existing `404`/`409`/`507` cases) rather than folding it into the default branch.
- `BaseChatViewController.uploadFileAtPath`'s completion handler adds a matching `case 429:` that presents an "Upload failed" alert with the localized message "Too many requests, please try again later".

The new user-facing string uses `NSLocalizedString`, so it is picked up by the existing localization extraction workflow (no manual `Localizable.strings` edits, matching how the surrounding strings are managed).

## Why this matters

Closes #2504. When the server rate-limits an upload it returns 429, but the app previously had no distinct handling for it, so the user was shown a generic "Unknown error occurred" alert with no indication that they were being rate-limited. The app already recognizes 429 elsewhere (message polling in `NCChatController`); this brings the upload path in line and tells the user what actually happened.

## Testing

- Verified the new 429 status flows through the real upload error path: `ChatFileUploader.uploadFile`'s `case 429` returns status code `429`, which is the value `BaseChatViewController.uploadFileAtPath`'s completion switches on.
- Confirmed existing handled codes (404/409 folder retry, 507 quota, 403 share failure) and the default unknown-error fallback are unchanged.
- Ran SwiftLint on the touched files; no new violations introduced by these changes.

Fixes #2504
