### PR TITLE
chore: Use macOS 26.5 and iOS 26.5 on CI

### DIFF
--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -24,16 +24,16 @@ permissions:
 
 env:
   WORKSPACE: NextcloudTalk.xcworkspace
-  DESTINATION: platform=iOS Simulator,name=iPhone 16,OS=18.5
-  SIMULATOR_MODEL: iPhone 16
-  SIMULATOR_VERSION: "18.5"
+  DESTINATION: platform=iOS Simulator,name=iPhone 17,OS=26.5
+  SIMULATOR_MODEL: iPhone 17
+  SIMULATOR_VERSION: "26.5"
   SCHEME: NextcloudTalk
-  XCODE_VERSION: "26.2"
+  XCODE_VERSION: "26.5"
 
 jobs:
   build:
     name: Build
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       # Workaround for eliminating iOS 17 simulators stalling issue
@@ -97,7 +97,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: macos-15
+    runs-on: macos-26
     needs: [build]
 
     strategy:

--- a/.github/workflows/talk-ios-tests.yml
+++ b/.github/workflows/talk-ios-tests.yml
@@ -73,11 +73,6 @@ jobs:
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
 
-    - name: Install iOS ${{ env.SIMULATOR_VERSION }}
-      run: |
-        xcrun simctl list > /dev/null # Required to prevent the next command from sometimes not working
-        xcodebuild -downloadPlatform iOS -buildVersion ${{ env.SIMULATOR_VERSION }}
-
     - name: Build NextcloudTalk iOS for testing
       run: |
         set -o pipefail && \
@@ -233,11 +228,6 @@ jobs:
       uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
       with:
         xcode-version: ${{ env.XCODE_VERSION }}
-
-    - name: Install iOS ${{ env.SIMULATOR_VERSION }}
-      run: |
-        xcrun simctl list > /dev/null # Required to prevent the next command from sometimes not working
-        xcodebuild -downloadPlatform iOS -buildVersion ${{ env.SIMULATOR_VERSION }}
 
     - name: Boot simulator
       uses: futureware-tech/simulator-action@e89aa8f93d3aec35083ff49d2854d07f7186f7f5 # v5.0.0

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -105,7 +105,6 @@ import UIKit
             self.textInputbar.counterStyle = .countdownReversed
         }
 
-        self.textInputbar.isTranslucent = false
         self.textInputbar.semanticContentAttribute = .forceLeftToRight
         self.textInputbar.contentInset = .init(top: 8, left: 4, bottom: 8, right: 4)
         self.textView.textContainerInset = .init(top: 8, left: 8, bottom: 8, right: 8)
@@ -148,8 +147,6 @@ import UIKit
         self.textView.layer.borderWidth = 1.0
         self.textView.layer.borderColor = UIColor.systemGray4.cgColor
 
-        // Hide default top border of UIToolbar
-        self.textInputbar.setShadowImage(UIImage(), forToolbarPosition: .any)
         self.textView.delegate = self
 
         self.autoCompletionView.register(AutoCompletionTableViewCell.self, forCellReuseIdentifier: AutoCompletionTableViewCell.identifier)

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -135,7 +135,7 @@ final class UIRoomTest: XCTestCase {
 
         // Send a test message
         let testMessage = "TestMessage"
-        let toolbar = app.toolbars["Toolbar"]
+        let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssert(textView.waitForExistence(timeout: TestConstants.timeoutShort))
         textView.tap()
@@ -203,9 +203,7 @@ final class UIRoomTest: XCTestCase {
         let testMessage = "TestMessage"
         let replyMessage = "ReplyMessage"
 
-        // Note: This will not work as of 26.3, the TextView cannot be found, as long as it is inside of an UIToolbar
-        // When switching UIToolbar -> UIView the TextView is correctly found
-        let toolbar = app.toolbars["Toolbar"]
+        let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssert(textView.waitForExistence(timeout: TestConstants.timeoutShort))
         textView.tap()
@@ -241,7 +239,7 @@ final class UIRoomTest: XCTestCase {
         self.createConversation(for: app, with: newConversationName)
 
         // Select a mention
-        let toolbar = app.toolbars["Toolbar"]
+        let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssert(textView.waitForExistence(timeout: TestConstants.timeoutShort))
         textView.tap()
@@ -346,7 +344,7 @@ final class UIRoomTest: XCTestCase {
         XCTAssert(!shareButton.exists)
 
         // Check that there's no inputbar
-        let toolbar = app.toolbars["Toolbar"]
+        let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssert(!textView.exists)
     }
@@ -385,7 +383,7 @@ final class UIRoomTest: XCTestCase {
 
         // Verify that we cannot send messages (no chat permission)
         // The toolbar/text input should not be present when user cannot chat
-        let toolbar = app.toolbars["Toolbar"]
+        let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssertFalse(textView.exists, "Text input should not exist when user cannot chat")
     }

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -101,6 +101,7 @@ final class UIRoomTest: XCTestCase {
         chatTitleView.tap()
 
         // Wait for admin participant to be visible (so participant list is loaded)
+        app.swipeUp()
         XCTAssert(app.staticTexts["admin"].waitForExistence(timeout: TestConstants.timeoutShort))
 
         // Leave open conversation


### PR DESCRIPTION
* Requires https://github.com/nextcloud-deps/SlackTextViewController/pull/27

GitHub starts using macOS 26 as `macos-latest` in June where iOS 18 is not shipped anymore. We are still using macOS 15 with iOS 18, so it's slowly time to upgrade for us as well (although, `macos-15` will be around for a bit)

Also, iOS 18 on macOS 26 doesn't look like a good idea: https://github.com/nextcloud/talk-ios/actions/runs/27909481863/job/82587199968?pr=2563

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
