### PR TITLE
chore: Remove files_types_order

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -5,7 +5,6 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count
   - empty_string
   - explicit_init
-  - file_types_order
   - unneeded_parentheses_in_closure_argument
 
 disabled_rules:
@@ -13,7 +12,6 @@ disabled_rules:
   - file_length
   - function_body_length
   - line_length
-  - file_types_order
 
 empty_count:
   severity: warning

--- a/NextcloudTalkTests/.swiftlint.yml
+++ b/NextcloudTalkTests/.swiftlint.yml
@@ -5,7 +5,6 @@ opt_in_rules: # some rules are turned off by default, so you need to opt-in
   - empty_count
   - empty_string
   - explicit_init
-  - file_types_order
   - unneeded_parentheses_in_closure_argument
 
 disabled_rules:


### PR DESCRIPTION
It's off by default 😓 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
