### PR TITLE
fix: Prevent duplicate peer crash in call collection view

### DIFF
--- a/NextcloudTalk/Calls/CallViewController.swift
+++ b/NextcloudTalk/Calls/CallViewController.swift
@@ -1876,7 +1876,7 @@ class CallViewController: UIViewController,
             }
 
             for peerConnection in self.screenPeersInCall {
-                let screenRenderer = self.screenRenderersDict[peerConnection.peerIdentifier]
+                let screenRenderer = self.screenRenderersDict[peerConnection.peerId]
                 self.screenRenderersDict.removeValue(forKey: peerConnection.peerId)
 
                 guard let screenRenderer else { continue }

--- a/NextcloudTalk/Calls/CallViewController.swift
+++ b/NextcloudTalk/Calls/CallViewController.swift
@@ -2367,6 +2367,14 @@ class CallViewController: UIViewController,
 
     func addPeer(_ peer: NCPeerConnection) {
         DispatchQueue.main.async {
+            // A peer can reach this method from both `peerJoined` and `didAddStream`. Deduplicate against
+            // the authoritative `peersInCall` as well as the pending inserts, by peerIdentifier, otherwise
+            // the same peer can be appended twice and crash the diffable data source on a duplicate item.
+            let alreadyAdded = self.peersInCall.contains { $0.peerIdentifier == peer.peerIdentifier }
+            let alreadyPending = self.pendingPeerInserts.contains { $0.peerIdentifier == peer.peerIdentifier }
+
+            guard !alreadyAdded, !alreadyPending else { return }
+
             // Store added time
             if peer.addedTime == 0 {
                 peer.addedTime = Int(Date().timeIntervalSince1970 * 1000)
@@ -2376,7 +2384,7 @@ class CallViewController: UIViewController,
                 // Don't delay adding the first peer
                 self.peersInCall.append(peer)
                 self.updateSnapshot()
-            } else if !self.pendingPeerInserts.contains(peer) {
+            } else {
                 // Delay updating the collection view a bit to allow batch updating
                 self.pendingPeerInserts.append(peer)
                 self.scheduleBatchCollectionViewUpdate()

--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -1131,6 +1131,8 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
 
     private func startSendingCurrentState() {
         DispatchQueue.main.async {
+            guard !self.isLeavingCall else { return }
+
             self.sendCurrentStateTimer?.invalidate()
             self.sendCurrentStateTimer = nil
 
@@ -1139,8 +1141,10 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
     }
 
     private func stopSendingCurrentState() {
-        self.sendCurrentStateTimer?.invalidate()
-        self.sendCurrentStateTimer = nil
+        DispatchQueue.main.async {
+            self.sendCurrentStateTimer?.invalidate()
+            self.sendCurrentStateTimer = nil
+        }
     }
 
     @objc private func sendCurrentState(withTimer timer: Timer?) {
@@ -1151,6 +1155,10 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
         }
 
         DispatchQueue.main.async {
+            // Don't send or re-arm the timer once we are leaving the call, otherwise an in-flight
+            // execution could keep broadcasting our state after the call ended.
+            guard !self.isLeavingCall else { return }
+
             self.sendNick()
             self.sendMediaState()
 

--- a/NextcloudTalk/WebRTC/NCPeerConnection.swift
+++ b/NextcloudTalk/WebRTC/NCPeerConnection.swift
@@ -105,7 +105,11 @@ public class NCPeerConnection: NSObject {
             return false
         }
 
-        return otherConnection.peerConnection === self.peerConnection
+        // Identify a peer by its peerIdentifier ("peerId-sid"), consistent with `hash` and with the
+        // collection view / renderer bookkeeping. Comparing the underlying peerConnection reference
+        // instead would treat a recreated wrapper for the same participant as a different peer, which
+        // breaks the diffable data source's identity and the contains/firstIndex guards built on it.
+        return otherConnection.peerIdentifier == self.peerIdentifier
     }
 
     // MARK: - Public


### PR DESCRIPTION
- [x] Prevent duplicate peer crash in call collection view
- [x] Stop sending current media state when leaving a call

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
