### PR TITLE
fix: Don't show read marker without message afterwards

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1450,6 +1450,8 @@ import SwiftUI
 
                 if let lastMessage, lastMessage.messageId > self.lastReadMessage {
                     // Iterate backwards to find the correct location for the unread message separator
+                    var foundOneMessage = false
+
                     for sectionIndex in self.dateSections.indices.reversed() {
                         let dateSection: Date = self.dateSections[sectionIndex]
 
@@ -1457,6 +1459,14 @@ import SwiftUI
 
                         for messageIndex in messages.indices.reversed() {
                             let message = messages[messageIndex]
+
+                            // The unread marker should never be inserted after the first message, as that would
+                            // show it without any message afterwards. Therefore we check if we found at least one
+                            // message, before adding the marker
+                            if !foundOneMessage {
+                                foundOneMessage = true
+                                continue
+                            }
 
                             if message.messageId > self.lastReadMessage {
                                 continue


### PR DESCRIPTION
How to reproduce (all on ios)
* Create a thread
* Write a few messages outside of the thread
* Write a few messages inside of the thread
* Mark the conversation as unread with swiping the conversation for unread
* Enter the conversation
* See that the read marker is at the very bottom of the chat, without any message afterwards


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
