### PR TITLE
fix: Scrolling when reaction is last message

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1679,8 +1679,8 @@ import SwiftUI
                     // Otherwise we would scroll whenever a unread message separator is available
                     if addedUnreadMessageSeparator, let indexPathUnreadMessageSeparator = self.indexPathForUnreadMessageSeparator() {
                         tableView.scrollToRow(at: indexPathUnreadMessageSeparator, at: .middle, animated: true)
-                    } else if (shouldScrollOnNewMessages || messages.containsMessage(forUserId: self.account.userId)), let lastIndexPath = self.getLastRealMessage()?.indexPath {
-                        tableView.scrollToRow(at: lastIndexPath, at: .none, animated: true)
+                    } else if shouldScrollOnNewMessages || messages.containsMessage(forUserId: self.account.userId), let lastIndexPath = self.getLastNonUpdateMessage()?.indexPath {
+                        tableView.scrollToRow(at: lastIndexPath, at: .bottom, animated: true)
                     } else if self.firstUnreadMessage == nil, newMessagesContainVisibleMessages, let firstNewMessage = messages.first {
                         // This check is needed since several calls to receiveMessages API might be needed
                         // (if the number of unread messages is bigger than the "limit" in receiveMessages request)


### PR DESCRIPTION
How to reproduce:
* Have a long message, that is larger than the screen
* Open the conversation so the messages are loaded and displayed
* Leave the conversation
* React from a different user and device to that message
* Reload the conversation list by swiping down (so the new messages are stored)
* Enter the conversation again

Without this PR: We scroll to the top of the last message
With this PR: We stay at the bottom


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
