### PR TITLE
fix: ContextChatViewController deallocation

### DIFF
--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -51,7 +51,6 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
     private var nextRoomWithMentionIndexPath: IndexPath?
     private var lastRoomWithMentionIndexPath: IndexPath?
     private var unreadMentionsBottomButton: UIButton!
-    private var contextChatNavigationController: NCNavigationController?
     private var activeFilter: RoomsFilter = .all
 
     private var contextMenuActionBlock: (() -> Void)?
@@ -1457,7 +1456,6 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         contextChatViewController.showContext(ofMessageId: messageId, withLimit: 50, withCloseButton: true)
 
         let contextChatNavigationController = NCNavigationController(rootViewController: contextChatViewController)
-        self.contextChatNavigationController = contextChatNavigationController
         self.present(contextChatNavigationController, animated: true)
     }
 

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -192,7 +192,7 @@ final class UIRoomTest: XCTestCase {
         // Search for the message we just wrote and open ContextChatViewController
         waitForReady(object: app.searchFields.firstMatch).tap()
         app.typeText(testMessage)
-        waitForReady(object: app.staticTexts[testMessage]).tap()
+        waitForReady(object: app.staticTexts.labelContains(testMessage).firstMatch, timeout: TestConstants.timeoutLong).tap()
 
         // Close the ContextChatViewController again
         let contextNavBar = app.navigationBars["NextcloudTalk.ContextChatView"]

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -135,7 +135,7 @@ final class UIRoomTest: XCTestCase {
         XCTAssert(debugLabel.waitForExistence(timeout: TestConstants.timeoutShort))
 
         // Send a test message
-        let testMessage = "TestMessage"
+        let testMessage = "TestMessage - DeAlloc"
         let toolbar = app.otherElements["SLKTextInputbar"]
         let textView = toolbar.textViews["Write message, @ to mention someone …"]
         XCTAssert(textView.waitForExistence(timeout: TestConstants.timeoutShort))
@@ -188,6 +188,18 @@ final class UIRoomTest: XCTestCase {
         // Go back to the main view controller
         XCTAssert(callOptionsButton.waitForExistence(timeout: TestConstants.timeoutShort))
         chatNavBar.buttons["Conversations"].tap()
+
+        // Search for the message we just wrote and open ContextChatViewController
+        waitForReady(object: app.searchFields.firstMatch).tap()
+        app.typeText(testMessage)
+        waitForReady(object: app.staticTexts[testMessage]).tap()
+
+        // Close the ContextChatViewController again
+        let contextNavBar = app.navigationBars["NextcloudTalk.ContextChatView"]
+        waitForReady(object: contextNavBar.buttons["Close"]).tap()
+
+        // Close the SearchController
+        app.buttons["close"].tap()
 
         // Check if all controllers are deallocated
         XCTAssert(app.staticTexts["{}"].waitForExistence(timeout: TestConstants.timeoutShort))


### PR DESCRIPTION
* Originally introduced at https://github.com/nextcloud/talk-ios/pull/1442/changes/a331aafed9d7c8b3820509dbbf61b920b2acd588
* While https://github.com/nextcloud/talk-ios/commit/aeeb7dba0b7528374de4a03d17e7475db130c586 removed the need to have it in a strong reference

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
