### PR TITLE
fix: Update displayname on signaling update

### DIFF
--- a/NextcloudTalk/WebRTC/SignalingParticipant.swift
+++ b/NextcloudTalk/WebRTC/SignalingParticipant.swift
@@ -43,5 +43,9 @@ import Foundation
     public func update(withUpdateDictionary dict: [AnyHashable: Any]) {
         self.actorId = dict["actorId"] as? String
         self.actorType = dict["actorType"] as? String
+
+        if let displayName = dict["displayName"] as? String {
+            self.displayName = displayName
+        }
     }
 }


### PR DESCRIPTION
When a guest user changes it's name, we receive an update message that contains the new displayname. We therefore need to update it in the signaling participant as well, so it is correctly used in typing indicators.
Note: This is only for the case where a guest joins later or changes the display later. If we join, we only receive a join dictionary where that property is missing.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
