### PR TITLE
fix: Memory leak from NCAPISessionManager

### DIFF
--- a/NextcloudTalk/Network/NCBaseSessionManager.swift
+++ b/NextcloudTalk/Network/NCBaseSessionManager.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-@objcMembers public class NCBaseSessionManager: AFHTTPSessionManager {
+@objcMembers public class NCBaseSessionManager: AFHTTPSessionManager, NSDiscardableContent {
 
     public var userAgent: String = NCAppBranding.userAgent()
 
@@ -36,5 +36,20 @@ import Foundation
         } else {
             completionHandler(.performDefaultHandling, nil)
         }
+    }
+
+    public func beginContentAccess() -> Bool {
+        return true
+    }
+
+    public func endContentAccess() {
+    }
+
+    public func discardContentIfPossible() {
+    }
+
+    public func isContentDiscarded() -> Bool {
+        // Return false to not get evicated from NSCache when moving to background
+        return false
     }
 }


### PR DESCRIPTION
How to test
* Check how many NCAPISessionManager objects exist
* Move app to background
* Open app again
* Check object count again, it is now increased by 1

This happens because of 2 things:
* `NSCache` tries to evict objects which are able to discard their content. This happens everytime the app is moved to the background. See also https://developer.apple.com/documentation/foundation/nscache/evictsobjectswithdiscardedcontent.
* `NSURLSession` keeps a strong reference to the delegate (see https://developer.apple.com/documentation/foundation/urlsession?language=objc). So even when the `NSCache` entry was evicted, the object was still retained.

To work around the issue we now implement `NSDiscardableContent` (https://developer.apple.com/documentation/foundation/nsdiscardablecontent) to specify, that the content was not discarded and therefore the object is not evicted.

As long as we use AFNetworking, I don't see a reason to further investigate the retention of the delegate..
 
## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
