### PR TITLE
feat: Improve file downloading handling

### DIFF
--- a/NextcloudTalk/AppDelegate.swift
+++ b/NextcloudTalk/AppDelegate.swift
@@ -65,6 +65,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
                 NCLog.removeOldLogfiles()
                 SDImageCache.shared.diskCache.removeExpiredData()
                 NCSettingsController.sharedInstance().createAccountsFile()
+
+                for account in NCDatabaseManager.sharedInstance().allAccounts() {
+                    NCChatFileController(account: account).removeOldFilesFromCache()
+                }
             }
         }
 

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -1346,7 +1346,7 @@ import Toast
         downloader.delegate = self
         downloader.messageType = kMessageTypeVoiceMessage
         downloader.actionType = actionTypeTranscribeVoiceMessage
-        downloader.downloadFile(fromMessage: message.file())
+        downloader.downloadFile(withFileId: message.file().parameterId)
     }
 
     func didPressEdit(for message: NCChatMessage) {
@@ -3902,7 +3902,7 @@ import Toast
 
         let downloader = NCChatFileController(account: self.account)
         downloader.delegate = self
-        downloader.downloadFile(fromMessage: fileParameter)
+        downloader.downloadFile(withFileId: fileParameter.parameterId)
     }
 
     public func cellHasDownloadedImagePreview(withSize size: CGSize, for message: NCChatMessage) {
@@ -3963,7 +3963,7 @@ import Toast
         let downloader = NCChatFileController(account: self.account)
         downloader.delegate = self
         downloader.messageType = kMessageTypeVoiceMessage
-        downloader.downloadFile(fromMessage: fileParameter)
+        downloader.downloadFile(withFileId: fileParameter.parameterId)
     }
 
     public func cellWants(toPauseAudioFile fileParameter: NCMessageFileParameter) {

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -1342,7 +1342,7 @@ import Toast
     }
 
     func didPressTranscribeVoiceMessage(for message: NCChatMessage) {
-        let downloader = NCChatFileController()
+        let downloader = NCChatFileController(account: self.account)
         downloader.delegate = self
         downloader.messageType = kMessageTypeVoiceMessage
         downloader.actionType = actionTypeTranscribeVoiceMessage
@@ -2039,10 +2039,7 @@ import Toast
 
         audioFileName += ".mp3"
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        let chatFileController = NCChatFileController()
-        chatFileController.initDownloadDirectory(for: activeAccount)
-
+        let chatFileController = NCChatFileController(account: self.account)
         let tempDirectoryURL = URL(fileURLWithPath: chatFileController.tempDirectoryPath)
         let destinationFilePath = tempDirectoryURL.appendingPathComponent(audioFileName).path
 
@@ -3866,7 +3863,7 @@ import Toast
 
     public func cellWants(toDownloadFile fileParameter: NCMessageFileParameter, for message: NCChatMessage) {
         if NCUtils.isImage(fileType: fileParameter.mimetype ?? "") {
-            let mediaViewController = NCMediaViewerViewController(initialMessage: message, room: self.room)
+            let mediaViewController = NCMediaViewerViewController(initialMessage: message, room: self.room, account: self.account)
             let navController = CustomPresentableNavigationController(rootViewController: mediaViewController)
 
             // Hiding the keyboard due to a UIKit issue where the reported keyboard height
@@ -3885,7 +3882,7 @@ import Toast
         if NCUtils.isVideo(fileType: fileParameter.mimetype ?? "") {
             // Skip unsupported formats here ("webm" and "mkv") and use VLC later
             if !fileExtension.isEmpty, !VLCKitVideoViewController.supportedFileExtensions.contains(fileExtension) {
-                let mediaViewController = NCMediaViewerViewController(initialMessage: message, room: self.room)
+                let mediaViewController = NCMediaViewerViewController(initialMessage: message, room: self.room, account: self.account)
                 let navController = CustomPresentableNavigationController(rootViewController: mediaViewController)
 
                 // Hiding the keyboard due to a UIKit issue where the reported keyboard height
@@ -3903,7 +3900,7 @@ import Toast
             return
         }
 
-        let downloader = NCChatFileController()
+        let downloader = NCChatFileController(account: self.account)
         downloader.delegate = self
         downloader.downloadFile(fromMessage: fileParameter)
     }
@@ -3963,7 +3960,7 @@ import Toast
             return
         }
 
-        let downloader = NCChatFileController()
+        let downloader = NCChatFileController(account: self.account)
         downloader.delegate = self
         downloader.messageType = kMessageTypeVoiceMessage
         downloader.downloadFile(fromMessage: fileParameter)

--- a/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell+File.swift
+++ b/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell+File.swift
@@ -181,7 +181,7 @@ extension BaseChatTableViewCell {
             return
         }
 
-        NCChatFileControllerWrapper.shared.downloadFile(withFileId: fileId) { fileLocalPath in
+        NCChatFileControllerWrapper.shared.downloadFile(withFileId: fileId, fromAccount: account) { fileLocalPath in
             // Check if we are still on the same cell
             guard let cellMessage = self.message, let imageView = self.filePreviewImageView, cellMessage.file().parameterId == fileId
             else {

--- a/NextcloudTalk/Chat/NCChatFileController.swift
+++ b/NextcloudTalk/Chat/NCChatFileController.swift
@@ -18,14 +18,14 @@ public protocol NCChatFileControllerDelegate: AnyObject {
 
 public class NCChatFileController: NSObject {
 
-    private static let deleteFilesOlderThanDays = 7
-
     public weak var delegate: NCChatFileControllerDelegate?
+
     public var messageType: String?
     public var actionType: String?
     public private(set) var tempDirectoryPath = ""
 
     private let account: TalkAccount
+    private let deleteFilesOlderThanDays = 7
     private var fileStatus: NCChatFileStatus?
 
     init(account: TalkAccount) {
@@ -49,15 +49,13 @@ public class NCChatFileController: NSObject {
             // Make sure our download directory exists
             try? fileManager.createDirectory(atPath: tempDirectoryPath, withIntermediateDirectories: true)
         }
-
-        removeOldFilesFromCache(thresholdDays: NCChatFileController.deleteFilesOlderThanDays)
     }
 
-    private func removeOldFilesFromCache(thresholdDays: Int) {
+    public func removeOldFilesFromCache() {
         let fileManager = FileManager.default
 
         guard let enumerator = fileManager.enumerator(atPath: tempDirectoryPath),
-              let thresholdDate = Calendar.current.date(byAdding: .day, value: -thresholdDays, to: Date())
+              let thresholdDate = Calendar.current.date(byAdding: .day, value: -deleteFilesOlderThanDays, to: Date())
         else { return }
 
         for case let file as String in enumerator {

--- a/NextcloudTalk/Chat/NCChatFileController.swift
+++ b/NextcloudTalk/Chat/NCChatFileController.swift
@@ -133,32 +133,6 @@ public class NCChatFileController: NSObject {
         try? FileManager.default.setAttributes(attributes, ofItemAtPath: filePath)
     }
 
-    public func downloadFile(fromMessage fileParameter: NCMessageFileParameter) {
-        let fileStatus = NCChatFileStatus(fileId: fileParameter.parameterId, fileName: fileParameter.name, filePath: fileParameter.path ?? "")
-        self.fileStatus = fileStatus
-        fileParameter.fileStatus = fileStatus
-
-        startDownload()
-    }
-
-    public func downloadFile(withFileId fileId: String) {
-        NCAPIController.sharedInstance().getFileById(forAccount: self.account, withFileId: fileId) { file, error in
-            guard let file else {
-                print("An error occurred while getting file with fileId \(fileId): \(error?.errorDescription ?? "")")
-                self.delegate?.fileControllerDidFailLoadingFile(self, withFileId: fileId, withErrorDescription: error?.errorDescription ?? "")
-                return
-            }
-
-            let remoteDavPrefix = "/remote.php/dav/files/\(self.account.userId)/"
-            let directoryPath = file.path.components(separatedBy: remoteDavPrefix).last ?? ""
-
-            let filePath = "\(directoryPath)\(file.fileName)"
-
-            self.fileStatus = NCChatFileStatus(fileId: file.fileId, fileName: file.fileName, filePath: filePath)
-            self.startDownload()
-        }
-    }
-
     public func moveFileToTemporaryDirectory(fromSourcePath sourcePath: String, destinationPath: String) -> Bool {
         let fileManager = FileManager.default
 
@@ -177,28 +151,29 @@ public class NCChatFileController: NSObject {
         }
     }
 
-    private func startDownload() {
-        guard let fileStatus else { return }
-
-        NCAPIController.sharedInstance().setupNCCommunication(forAccount: self.account)
-
-        let serverUrlFileName = "\(self.account.server)\(NCAPIController.sharedInstance().filesPath(forAccount: self.account))/\(fileStatus.filePath)"
-        let fileLocalPath = (tempDirectoryPath as NSString).appendingPathComponent(fileStatus.fileName)
-        fileStatus.fileLocalPath = fileLocalPath
-
-        // Setting just isDownloading without a concrete progress will show an indeterminate activity indicator
-        didChangeIsDownloadingNotification(isDownloading: true)
-
-        // First read metadata from the file and check if we already downloaded it
-        let options = NKRequestOptions(timeout: 60, queue: .main)
-        NextcloudKit.shared.readFileOrFolder(serverUrlFileName: serverUrlFileName, depth: "0", showHiddenFiles: true, options: options) { _, files, _, error in
-            guard error.errorCode == 0, files.count == 1, let file = files.first else {
-                self.didChangeIsDownloadingNotification(isDownloading: false)
-
-                print("Error downloading file: \(error.errorCode) - \(error.errorDescription)")
-                self.delegate?.fileControllerDidFailLoadingFile(self, withFileId: fileStatus.fileId, withErrorDescription: error.errorDescription)
+    public func downloadFile(withFileId fileId: String) {
+        // getFileById already sets up NextcloudKit
+        NCAPIController.sharedInstance().getFileById(forAccount: self.account, withFileId: fileId) { file, error in
+            guard let file else {
+                print("An error occurred while getting file with fileId \(fileId): \(error?.errorDescription ?? "")")
+                self.delegate?.fileControllerDidFailLoadingFile(self, withFileId: fileId, withErrorDescription: error?.errorDescription ?? "")
                 return
             }
+
+            let remoteDavPrefix = "/remote.php/dav/files/\(self.account.userId)/"
+            let directoryPath = file.path.components(separatedBy: remoteDavPrefix).last ?? ""
+
+            let filePath = "\(directoryPath)\(file.fileName)"
+
+            let fileStatus = NCChatFileStatus(fileId: file.fileId, fileName: file.fileName, filePath: filePath)
+            self.fileStatus = fileStatus
+
+            let serverUrlFileName = "\(self.account.server)\(NCAPIController.sharedInstance().filesPath(forAccount: self.account))/\(fileStatus.filePath)"
+            let fileLocalPath = (self.tempDirectoryPath as NSString).appendingPathComponent(fileStatus.fileName)
+            fileStatus.fileLocalPath = fileLocalPath
+
+            // Setting just isDownloading without a concrete progress will show an indeterminate activity indicator
+            self.didChangeIsDownloadingNotification(isDownloading: true)
 
             // File exists on server -> check our cache
             if self.isFileInCache(fileLocalPath, withModificationDate: file.date as Date, withSize: file.size) {

--- a/NextcloudTalk/Chat/NCChatFileController.swift
+++ b/NextcloudTalk/Chat/NCChatFileController.swift
@@ -25,10 +25,19 @@ public class NCChatFileController: NSObject {
     public var actionType: String?
     public private(set) var tempDirectoryPath = ""
 
+    private let account: TalkAccount
     private var fileStatus: NCChatFileStatus?
 
-    public func initDownloadDirectory(for account: TalkAccount) {
-        let encodedAccountId = account.accountId.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
+    init(account: TalkAccount) {
+        self.account = account
+
+        super.init()
+
+        self.initDownloadDirectory()
+    }
+
+    private func initDownloadDirectory() {
+        let encodedAccountId = self.account.accountId.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? ""
         let fileManager = FileManager.default
 
         tempDirectoryPath = (NSTemporaryDirectory() as NSString).appendingPathComponent("download")
@@ -63,21 +72,18 @@ public class NCChatFileController: NSObject {
         }
     }
 
-    public func deleteDownloadDirectory(for account: TalkAccount) {
-        initDownloadDirectory(for: account)
+    public func deleteDownloadDirectory() {
         try? FileManager.default.removeItem(atPath: tempDirectoryPath)
 
         print("Deleted download directory: \(tempDirectoryPath)")
     }
 
-    public func clearDownloadDirectory(for account: TalkAccount) {
-        deleteDownloadDirectory(for: account)
-        initDownloadDirectory(for: account)
+    public func clearDownloadDirectory() {
+        deleteDownloadDirectory()
+        initDownloadDirectory()
     }
 
-    public func getDiskUsage(for account: TalkAccount) -> Int {
-        initDownloadDirectory(for: account)
-
+    public func getDiskUsage() -> Int {
         let fileManager = FileManager.default
 
         guard let enumerator = fileManager.enumerator(atPath: tempDirectoryPath) else { return 0 }
@@ -114,7 +120,7 @@ public class NCChatFileController: NSObject {
     }
 
     private func setDate(onFile filePath: String, withCreationDate creationDate: Date?, withModificationDate modificationDate: Date?) {
-        var attributes = [FileAttributeKey : Any]()
+        var attributes = [FileAttributeKey: Any]()
 
         if let creationDate {
             attributes[.creationDate] = creationDate
@@ -138,16 +144,14 @@ public class NCChatFileController: NSObject {
     }
 
     public func downloadFile(withFileId fileId: String) {
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-
-        NCAPIController.sharedInstance().getFileById(forAccount: activeAccount, withFileId: fileId) { file, error in
+        NCAPIController.sharedInstance().getFileById(forAccount: self.account, withFileId: fileId) { file, error in
             guard let file else {
                 print("An error occurred while getting file with fileId \(fileId): \(error?.errorDescription ?? "")")
                 self.delegate?.fileControllerDidFailLoadingFile(self, withFileId: fileId, withErrorDescription: error?.errorDescription ?? "")
                 return
             }
 
-            let remoteDavPrefix = "/remote.php/dav/files/\(activeAccount.userId)/"
+            let remoteDavPrefix = "/remote.php/dav/files/\(self.account.userId)/"
             let directoryPath = file.path.components(separatedBy: remoteDavPrefix).last ?? ""
 
             let filePath = "\(directoryPath)\(file.fileName)"
@@ -158,9 +162,6 @@ public class NCChatFileController: NSObject {
     }
 
     public func moveFileToTemporaryDirectory(fromSourcePath sourcePath: String, destinationPath: String) -> Bool {
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
-        initDownloadDirectory(for: activeAccount)
-
         let fileManager = FileManager.default
 
         if fileManager.fileExists(atPath: destinationPath) {
@@ -181,12 +182,9 @@ public class NCChatFileController: NSObject {
     private func startDownload() {
         guard let fileStatus else { return }
 
-        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        NCAPIController.sharedInstance().setupNCCommunication(forAccount: self.account)
 
-        NCAPIController.sharedInstance().setupNCCommunication(forAccount: activeAccount)
-        initDownloadDirectory(for: activeAccount)
-
-        let serverUrlFileName = "\(activeAccount.server)\(NCAPIController.sharedInstance().filesPath(forAccount: activeAccount))/\(fileStatus.filePath)"
+        let serverUrlFileName = "\(self.account.server)\(NCAPIController.sharedInstance().filesPath(forAccount: self.account))/\(fileStatus.filePath)"
         let fileLocalPath = (tempDirectoryPath as NSString).appendingPathComponent(fileStatus.fileName)
         fileStatus.fileLocalPath = fileLocalPath
 

--- a/NextcloudTalk/Chat/NCChatFileController.swift
+++ b/NextcloudTalk/Chat/NCChatFileController.swift
@@ -34,6 +34,11 @@ public class NCChatFileController: NSObject {
         super.init()
 
         self.initDownloadDirectory()
+        AllocationTracker.shared.addAllocation()
+    }
+
+    deinit {
+        AllocationTracker.shared.removeAllocation()
     }
 
     private func initDownloadDirectory() {

--- a/NextcloudTalk/Chat/NCChatFileController.swift
+++ b/NextcloudTalk/Chat/NCChatFileController.swift
@@ -113,12 +113,20 @@ public class NCChatFileController: NSObject {
         return false
     }
 
-    private func setCreationDate(onFile filePath: String, withCreationDate date: Date) {
-        try? FileManager.default.setAttributes([.creationDate: date], ofItemAtPath: filePath)
-    }
+    private func setDate(onFile filePath: String, withCreationDate creationDate: Date?, withModificationDate modificationDate: Date?) {
+        var attributes = [FileAttributeKey : Any]()
 
-    private func setModificationDate(onFile filePath: String, withModificationDate date: Date) {
-        try? FileManager.default.setAttributes([.modificationDate: date], ofItemAtPath: filePath)
+        if let creationDate {
+            attributes[.creationDate] = creationDate
+        }
+
+        if let modificationDate {
+            attributes[.modificationDate] = modificationDate
+        }
+
+        guard !attributes.isEmpty else { return }
+
+        try? FileManager.default.setAttributes(attributes, ofItemAtPath: filePath)
     }
 
     public func downloadFile(fromMessage fileParameter: NCMessageFileParameter) {
@@ -213,10 +221,8 @@ public class NCChatFileController: NSObject {
             } completionHandler: { _, _, _, _, _, error in
                 if error.errorCode == 0 {
                     // Set modification date to invalidate our cache
-                    self.setModificationDate(onFile: fileLocalPath, withModificationDate: file.date as Date)
-
                     // Set creation date to delete older files from cache
-                    self.setCreationDate(onFile: fileLocalPath, withCreationDate: Date())
+                    self.setDate(onFile: fileLocalPath, withCreationDate: Date(), withModificationDate: file.date as Date)
 
                     self.delegate?.fileControllerDidLoadFile(self, with: fileStatus)
                 } else {

--- a/NextcloudTalk/Chat/NCChatFileControllerWrapper.swift
+++ b/NextcloudTalk/Chat/NCChatFileControllerWrapper.swift
@@ -15,7 +15,7 @@ public class NCChatFileControllerWrapper: NSObject, NCChatFileControllerDelegate
     static let shared = NCChatFileControllerWrapper()
 
     @MainActor
-    public func downloadFile(withFileId fileId: String, completionBlock: @escaping (_ fileLocalPath: String?) -> Void) {
+    public func downloadFile(withFileId fileId: String, fromAccount account: TalkAccount, completionBlock: @escaping (_ fileLocalPath: String?) -> Void) {
         if var existingBlocks = completionBlocks[fileId] {
             // We are already downloading this file, don't do it again, just ensure we call the completion block later on
             existingBlocks.append(completionBlock)
@@ -26,7 +26,7 @@ public class NCChatFileControllerWrapper: NSObject, NCChatFileControllerDelegate
 
         completionBlocks[fileId, default: []].append(completionBlock)
 
-        let fileController = NCChatFileController()
+        let fileController = NCChatFileController(account: account)
         fileController.delegate = self
 
         fileControllers[fileId] = fileController

--- a/NextcloudTalk/Media Viewer/NCMediaViewerPageViewController.swift
+++ b/NextcloudTalk/Media Viewer/NCMediaViewerPageViewController.swift
@@ -118,7 +118,7 @@ import SwiftyGif
         self.activityIndicator.startAnimating()
 
         fileDownloader.delegate = self
-        fileDownloader.downloadFile(fromMessage: self.message.file())
+        fileDownloader.downloadFile(withFileId: self.message.file().parameterId)
 
         self.navigationItem.title = self.message.file().name
 

--- a/NextcloudTalk/Media Viewer/NCMediaViewerPageViewController.swift
+++ b/NextcloudTalk/Media Viewer/NCMediaViewerPageViewController.swift
@@ -19,7 +19,8 @@ import SwiftyGif
     public weak var delegate: NCMediaViewerPageViewControllerDelegate?
 
     public let message: NCChatMessage
-    private let fileDownloader = NCChatFileController()
+    private let account: TalkAccount
+    private let fileDownloader: NCChatFileController
 
     private lazy var zoomableView = {
         let zoomableView = NCZoomableView()
@@ -87,8 +88,11 @@ import SwiftyGif
         return indicator
     }()
 
-    init(message: NCChatMessage) {
+    init(message: NCChatMessage, account: TalkAccount) {
         self.message = message
+        self.account = account
+
+        self.fileDownloader = NCChatFileController(account: account)
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/NextcloudTalk/Media Viewer/NCMediaViewerViewController.swift
+++ b/NextcloudTalk/Media Viewer/NCMediaViewerViewController.swift
@@ -12,6 +12,7 @@ import UIKit
                                                 NCMediaViewerPageViewControllerDelegate {
 
     private let room: NCRoom
+    private let account: TalkAccount
     private let pageController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
     private var initialMessage: NCChatMessage
 
@@ -59,9 +60,10 @@ import UIKit
         return showMessageButton
     }()
 
-    init(initialMessage: NCChatMessage, room: NCRoom) {
+    init(initialMessage: NCChatMessage, room: NCRoom, account: TalkAccount) {
         self.room = room
         self.initialMessage = initialMessage
+        self.account = account
 
         super.init(nibName: nil, bundle: nil)
     }
@@ -91,7 +93,7 @@ import UIKit
 
         self.pageController.didMove(toParent: self)
 
-        let initialViewController = NCMediaViewerPageViewController(message: self.initialMessage)
+        let initialViewController = NCMediaViewerPageViewController(message: self.initialMessage, account: self.account)
         initialViewController.delegate = self
         self.pageController.setViewControllers([initialViewController], direction: .forward, animated: false)
 
@@ -194,7 +196,7 @@ import UIKit
               let prevMessage = self.getPreviousFileMessage(from: prevMediaPageVC.message)
         else { return nil }
 
-        let mediaPageViewController = NCMediaViewerPageViewController(message: prevMessage)
+        let mediaPageViewController = NCMediaViewerPageViewController(message: prevMessage, account: self.account)
         mediaPageViewController.delegate = self
         return mediaPageViewController
     }
@@ -204,7 +206,7 @@ import UIKit
               let nextMessage = self.getNextFileMessage(from: prevMediaPageVC.message)
         else { return nil }
 
-        let mediaPageViewController = NCMediaViewerPageViewController(message: nextMessage)
+        let mediaPageViewController = NCMediaViewerPageViewController(message: nextMessage, account: self.account)
         mediaPageViewController.delegate = self
         return mediaPageViewController
     }

--- a/NextcloudTalk/Rooms/RoomInfo/RoomInfoFileSection.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/RoomInfoFileSection.swift
@@ -60,9 +60,11 @@ struct RoomInfoFileSection: View {
     }
 
     func previewFile() {
+        guard let account = room.account else { return }
+
         self.isDownloadingPreview = true
 
-        NCChatFileControllerWrapper.shared.downloadFile(withFileId: room.objectId) { @MainActor fileLocalPath in
+        NCChatFileControllerWrapper.shared.downloadFile(withFileId: room.objectId, fromAccount: account) { @MainActor fileLocalPath in
             self.isDownloadingPreview = false
 
             guard let fileLocalPath else { return }

--- a/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
@@ -264,7 +264,7 @@ import PassKit
 
         let downloader = NCChatFileController(account: account)
         downloader.delegate = self
-        downloader.downloadFile(fromMessage: file)
+        downloader.downloadFile(withFileId: file.parameterId)
     }
 
     func fileControllerDidLoadFile(_ fileController: NCChatFileController, with fileStatus: NCChatFileStatus) {

--- a/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomSharedItemsTableViewController.swift
@@ -258,8 +258,11 @@ import PassKit
     // MARK: - File downloader
 
     func downloadFileForCell(cell: DirectoryTableViewCell, file: NCMessageFileParameter) {
+        guard let account = self.room.account else { return }
+
         cell.fileParameter = file
-        let downloader = NCChatFileController()
+
+        let downloader = NCChatFileController(account: account)
         downloader.delegate = self
         downloader.downloadFile(fromMessage: file)
     }

--- a/NextcloudTalk/Settings/NCSettingsController.swift
+++ b/NextcloudTalk/Settings/NCSettingsController.swift
@@ -439,7 +439,7 @@ public class NCSettingsController: NSObject {
         NCAPIController.sharedInstance().removeProfileImage(forAccount: removingAccount)
         NCAPIController.sharedInstance().removeAPISessionManager(forAccount: removingAccount)
         NCDatabaseManager.sharedInstance().removeAccount(withAccountId: removingAccount.accountId)
-        NCChatFileController().deleteDownloadDirectory(for: removingAccount)
+        NCChatFileController(account: removingAccount).deleteDownloadDirectory()
         NCRoomsManager.shared.chatViewController?.leaveChat()
         self.createAccountsFile()
 

--- a/NextcloudTalk/Settings/SettingsTableViewController.swift
+++ b/NextcloudTalk/Settings/SettingsTableViewController.swift
@@ -551,13 +551,10 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
             preferredStyle: .alert)
 
         let clearAction = UIAlertAction(title: NSLocalizedString("Clear cache", comment: ""), style: .destructive) { _ in
-            let fileController = NCChatFileController()
             let talkAccounts = NCDatabaseManager.sharedInstance().allAccounts()
 
-            if let talkAccounts = talkAccounts as? [TalkAccount] {
-                for account in talkAccounts {
-                    fileController.clearDownloadDirectory(for: account)
-                }
+            for account in talkAccounts {
+                NCChatFileController(account: account).clearDownloadDirectory()
             }
 
             self.updateTotalFileCacheSize()
@@ -1020,11 +1017,10 @@ extension SettingsTableViewController {
     func updateTotalFileCacheSize() {
         self.totalFileCacheSize = 0
 
-        let fileController = NCChatFileController()
         let talkAccounts = NCDatabaseManager.sharedInstance().allAccounts()
 
         for account in talkAccounts {
-            self.totalFileCacheSize += Int(fileController.getDiskUsage(for: account))
+            self.totalFileCacheSize += Int(NCChatFileController(account: account).getDiskUsage())
         }
     }
 }


### PR DESCRIPTION
* Fixes #2054
* Fixes #2402

We already do a request to check if our local file cache is up to date, but it is currently based on the path. This PR changes it to always use the fileId, which makes it path independent, while not doing additional requests.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
