### PR TITLE
chore: WebRTC 150 + NWPathMonitor

### DIFF
--- a/NextcloudTalk.xcodeproj/project.pbxproj
+++ b/NextcloudTalk.xcodeproj/project.pbxproj
@@ -3458,7 +3458,7 @@
 			repositoryURL = "https://github.com/nextcloud-releases/talk-clients-webrtc";
 			requirement = {
 				kind = revision;
-				revision = 01a2cc9c4c2afcb266bc56c7f6228b737d8b4cdd;
+				revision = 904c6624658e65786ac098597e05ef77072cc0d9;
 			};
 		};
 		1FBB6EE12F8ECE5B003CBA30 /* XCRemoteSwiftPackageReference "Toast-Swift" */ = {

--- a/NextcloudTalk/WebRTC/WebRTCCommon.swift
+++ b/NextcloudTalk/WebRTC/WebRTCCommon.swift
@@ -10,6 +10,10 @@ import Foundation
     public static let shared = WebRTCCommon()
 
     public lazy var peerConnectionFactory: RTCPeerConnectionFactory = {
+        // Ref https://github.com/nextcloud/talk-ios/issues/1912
+        // Ref https://issues.webrtc.org/issues/502461765
+        RTCInitFieldTrialDictionary([kRTCFieldTrialUseNWPathMonitor: kRTCFieldTrialEnabledValue])
+
         return RTCPeerConnectionFactory(encoderFactory: encoderFactory, decoderFactory: decoderFactory)
     }()
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ You got stuck while working on a issue or need some pointers? Feel free to ask i
 
 We are using our own builds of the WebRTC library. They can be found in this [repository](https://github.com/nextcloud-releases/talk-clients-webrtc).
 
-Current version: [147.7727.0](https://github.com/nextcloud-releases/talk-clients-webrtc/releases/tag/147.7727.0).
+Current version: [150.7871.0](https://github.com/nextcloud-releases/talk-clients-webrtc/releases/tag/150.7871.0).
 
 ## Running tests locally
 


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/1912

Updates to WebRTC 150.7871.0 and enables NWPathMonitor field trial. There are multiple reports that this should fix dual sim iPhones (e.g. https://issues.webrtc.org/issues/502461765). The issue reported at https://issues.webrtc.org/issues/359245764 has been fixed meanwhile and is included upstream.

One thing we should keep in mind is https://issues.webrtc.org/issues/421933206 // https://webrtc-review.googlesource.com/c/src/+/394341. In worst case we can include it in our build ourselves. 

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
