### PR TITLE
fix: Stop screensharing only for own peer

### DIFF
--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -614,6 +614,8 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
     public func stopScreenshare() {
         WebRTCCommon.shared.assertQueue()
 
+        guard self.screensharingActive else { return }
+
         self.screensharingController.stopCapture()
 
         if let externalSignalingController {
@@ -1330,7 +1332,7 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
 
     func peerConnection(_ peerConnection: NCPeerConnection, didChange newState: RTCIceConnectionState) {
         if newState == .failed {
-            if peerConnection.roomType == kRoomTypeScreen {
+            if peerConnection.isOwnScreensharePeer {
                 self.stopScreenshare()
                 return
             }


### PR DESCRIPTION
When a peer fails we stop screensharing in all cases, even if it's not our own screenshare. So we never recover a foreign screenshare.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
