### PR TITLE
fix: Don't retain option menu for threads

### DIFF
--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -411,7 +411,7 @@ import SwiftUI
 
                     let message = thread.lastMessage() ?? thread.firstMessage()
 
-                    let action = UIAction(title: thread.title, handler: { _ in
+                    let action = UIAction(title: thread.title, handler: { [unowned self] _ in
                         guard let message else { return }
                         self.didPressShowThread(for: message)
                     })


### PR DESCRIPTION
Noticed by chance.

Reproduction 1:
* Opening the "..." menu
* Swiping left to go back to the conversation list

Reproduction 2:
* Be on account A
* Opening the "..." menu in 
* Receive a push of account B
* Tap on the notification


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
