### PR TITLE
fix: Allow older messages on chat relay

### DIFF
--- a/NextcloudTalk/Chat/NCChatController.swift
+++ b/NextcloudTalk/Chat/NCChatController.swift
@@ -282,12 +282,13 @@ public class NCChatController: NSObject {
     }
 
     private func updateLastChatBlock(withNewestKnown newestKnown: Int) {
+        guard newestKnown > 0 else { return }
+
         let realm = RLMRealm.default()
         try? realm.transaction {
             let managedSortedBlocks = self.managedSortedBlocksForRoomOrThread()
-            let lastBlock = managedSortedBlocks.lastObject() as? NCChatBlock
-            if newestKnown > 0 {
-                lastBlock?.newestMessageId = newestKnown
+            if let lastBlock = managedSortedBlocks.lastObject() as? NCChatBlock, newestKnown > lastBlock.newestMessageId {
+                lastBlock.newestMessageId = newestKnown
             }
         }
     }

--- a/NextcloudTalk/Chat/NCChatController.swift
+++ b/NextcloudTalk/Chat/NCChatController.swift
@@ -542,9 +542,11 @@ public class NCChatController: NSObject {
         let lastChatBlock = chatBlocksForRoomOrThread().last
         let lastNewestMessageId = lastChatBlock?.newestMessageId ?? 0
 
-        if message.messageId <= lastNewestMessageId {
-            return
-        }
+        // We allow older messages here, since chat relay might be received out of order (e.g. with call summary bot)
+        // Ref: https://github.com/nextcloud/talk-ios/issues/2580
+        // if message.messageId <= lastNewestMessageId {
+        //     return
+        // }
 
         // A file share parent in the relay payload carries the sender's file path and link. Storing it
         // would overwrite the correct per-user values in the database (see nextcloud/spreed#18572), so


### PR DESCRIPTION
* Fixes https://github.com/nextcloud/talk-ios/issues/2580

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
