### PR TITLE
fix: Improve unread separator animation

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -593,12 +593,22 @@ import Toast
         DispatchQueue.main.async {
             let lastSectionBeforeUpdate = self.dateSections.count - 1
 
+            // The user just wrote a message, so the unread messages separator is obsolete.
+            // Remove it in the same batch update that inserts the temporary message: a
+            // standalone deletion later (when the own message is received back) would
+            // interrupt the insert/scroll animation that is started here.
+            let separatorIndexPath = self.removeUnreadMessagesSeparatorFromDataSource()
+
             self.appendMessages(messages: [temporaryMessage])
 
             if let lastDateSection = self.dateSections.last, let messagesForLastDate = self.messages[lastDateSection] {
                 let lastMessageIndexPath = IndexPath(row: messagesForLastDate.count - 1, section: self.dateSections.count - 1)
 
                 self.tableView?.beginUpdates()
+
+                if let separatorIndexPath {
+                    self.tableView?.deleteRows(at: [separatorIndexPath], with: .fade)
+                }
 
                 let newLastSection = self.dateSections.count - 1
                 if lastSectionBeforeUpdate != newLastSection {
@@ -3792,10 +3802,19 @@ import Toast
         return self.indexPathAndMessageFromEnd(with: { _ in return true })?.indexPath
     }
 
+    // Removes the unread messages separator from the data source and returns the index path
+    // it occupied, so callers can bundle the tableView deletion into their own batch update
+    internal func removeUnreadMessagesSeparatorFromDataSource() -> IndexPath? {
+        guard let indexPath = self.indexPathForUnreadMessageSeparator() else { return nil }
+
+        let separatorDate = self.dateSections[indexPath.section]
+        self.messages[separatorDate]?.remove(at: indexPath.row)
+
+        return indexPath
+    }
+
     internal func removeUnreadMessagesSeparator() {
-        if let indexPath = self.indexPathForUnreadMessageSeparator() {
-            let separatorDate = self.dateSections[indexPath.section]
-            self.messages[separatorDate]?.remove(at: indexPath.row)
+        if let indexPath = self.removeUnreadMessagesSeparatorFromDataSource() {
             self.tableView?.deleteRows(at: [indexPath], with: .fade)
         }
     }

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1597,8 +1597,11 @@ import SwiftUI
                 var addedUnreadMessageSeparator = false
                 var unreadMessageSeparatorPosition: (sectionKey: Date, row: Int)?
 
-                // Check if unread messages separator should be added (only if it's not already shown)
+                // Check if unread messages separator should be added (only if it's not already shown).
+                // A message written by the user (e.g. sent from another device) removes the separator,
+                // so don't add it in the first place when the received messages contain one.
                 if firstNewMessagesAfterHistory, let lastRealMessage = self.getLastRealMessage(), self.indexPathForUnreadMessageSeparator() == nil, newMessagesContainVisibleMessages,
+                   !messages.containsMessage(forUserId: self.account.userId),
                    let lastDateSection = self.dateSections.last, var messagesBeforeUpdate = self.messages[lastDateSection] {
 
                     // Store the messageId separately from self.lastReadMessage as that might change during a room update
@@ -1607,6 +1610,19 @@ import SwiftUI
                     self.messages[lastDateSection] = messagesBeforeUpdate
                     unreadMessageSeparatorPosition = (lastDateSection, messagesBeforeUpdate.count - 1)
                     addedUnreadMessageSeparator = true
+                }
+
+                // Receiving a message written by the user (e.g. sent from another device) removes
+                // the unread messages separator. Remove it right before the batch update that
+                // inserts the received messages: both run in the same runloop tick, so their
+                // animations still play together, while a removal in the batch update's completion
+                // would run as a second, visibly separate animation. Keeping the removal out of
+                // the batch update itself also keeps the update free of deletions, whose pre-update
+                // coordinates would need to be compensated against the inserted sections and rows.
+                // For messages sent from this device the separator was already removed together
+                // with the insertion of the temporary message.
+                if messages.containsMessage(forUserId: self.account.userId) {
+                    self.removeUnreadMessagesSeparator()
                 }
 
                 var update = self.appendReceivedMessagesAndComputeTableViewUpdate(for: messages, in: tableView)
@@ -1626,10 +1642,6 @@ import SwiftUI
                 if update.isEmpty {
                     // All received messages were updated in place, so the temporary messages are
                     // already visible and scrolled to -> only the bookkeeping of the batch update is left
-                    if messages.containsMessage(forUserId: self.account.userId) {
-                        self.removeUnreadMessagesSeparator()
-                    }
-
                     if let lastReceivedMessage = messages.last {
                         self.lastReadMessage = lastReceivedMessage.messageId
                     }
@@ -1648,11 +1660,6 @@ import SwiftUI
                         }
 
                     } completion: { _ in
-                        // Remove unread messages separator when user writes a message
-                        if messages.containsMessage(forUserId: self.account.userId) {
-                            self.removeUnreadMessagesSeparator()
-                        }
-
                         // Only scroll to unread message separator if we added it while processing the received messages
                         // Otherwise we would scroll whenever a unread message separator is available
                         if addedUnreadMessageSeparator, let indexPathUnreadMessageSeparator = self.indexPathForUnreadMessageSeparator() {

--- a/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
+++ b/NextcloudTalkTests/Unit/Chat/UnitChatViewControllerTest.swift
@@ -261,6 +261,7 @@ final class UnitChatViewControllerTest: TestBaseRealm {
         message.accountId = account.accountId
         message.actorId = actorId
         message.actorType = "users"
+        message.actorDisplayName = "DisplayName \(actorId)"
         message.timestamp = timestamp
         message.token = room.token
         message.message = "Message \(id)"
@@ -377,5 +378,99 @@ final class UnitChatViewControllerTest: TestBaseRealm {
         // The echo reloads the known message in the section the tableView still knows as 0,
         // even though it is section 1 in the updated data source
         XCTAssertEqual(update.reloadIndexPaths, [IndexPath(row: 0, section: 0)])
+    }
+
+    // A received message written by the user (e.g. sent from another device) removes the
+    // unread messages separator. The removal runs right before the batch update that inserts
+    // the received messages, so the insert coordinates must account for the deleted row.
+    func testReceivedOwnMessageRemovesUnreadSeparator() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let room = addRoom(withToken: "batchSeparatorRemoval")
+        let chatViewController = try XCTUnwrap(ChatViewController(forRoom: room, withAccount: activeAccount))
+        chatViewController.loadViewIfNeeded()
+        let tableView = try XCTUnwrap(chatViewController.tableView)
+
+        let now = Int(Date().timeIntervalSince1970)
+
+        // Existing state: a message from another user with the unread messages separator below it
+        chatViewController.appendMessages(messages: [makeMessage(id: 1, timestamp: now - 60, actorId: "bob", inRoom: room, withAccount: activeAccount)])
+
+        let separator = NCChatMessage()
+        separator.messageId = MessageSeparatorTableViewCell.unreadMessagesSeparatorId
+        let lastDateSection = try XCTUnwrap(chatViewController.dateSections.last)
+        chatViewController.messages[lastDateSection]?.append(separator)
+
+        // Force a layout pass so the reload is actually performed: the view is not part of a
+        // window here, so the table would otherwise lazily reload against the data source only
+        // when the batch update runs - at that point it was already mutated, so the update's
+        // pre-update coordinates would not match and performBatchUpdates would raise
+        tableView.reloadData()
+        tableView.layoutIfNeeded()
+        XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
+        XCTAssertNotNil(chatViewController.indexPathForUnreadMessageSeparator())
+
+        // Receive an own message, e.g. sent from another device
+        let ownMessage = makeMessage(id: 2, timestamp: now, actorId: activeAccount.userId, inRoom: room, withAccount: activeAccount)
+        let notification = Notification(name: .NCChatControllerDidReceiveChatMessages,
+                                        object: chatViewController.chatController,
+                                        userInfo: ["messages": [ownMessage]])
+        chatViewController.didReceiveChatMessages(notification: notification)
+
+        // didReceiveChatMessages processes the received messages asynchronously on the main queue
+        let processed = expectation(description: "Processed received messages")
+        DispatchQueue.main.async { processed.fulfill() }
+        wait(for: [processed], timeout: TestConstants.timeoutShort)
+
+        // Separator removed and own message inserted in the same runloop tick. Wrong
+        // coordinates would raise NSInternalInconsistencyException inside performBatchUpdates.
+        XCTAssertNil(chatViewController.indexPathForUnreadMessageSeparator())
+        XCTAssertEqual(tableView.numberOfSections, 1)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 0), 2)
+        XCTAssertEqual(chatViewController.message(for: IndexPath(row: 1, section: 0))?.messageId, 2)
+    }
+
+    // Same as above, but the received messages also create a section for an older day, so the
+    // batch update combines the separator removal with a section insert that shifts the
+    // separator's section index.
+    func testReceivedOwnMessageRemovesUnreadSeparatorWhenOlderDaySectionIsInserted() throws {
+        let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
+        let room = addRoom(withToken: "batchSeparatorShifted")
+        let chatViewController = try XCTUnwrap(ChatViewController(forRoom: room, withAccount: activeAccount))
+        chatViewController.loadViewIfNeeded()
+        let tableView = try XCTUnwrap(chatViewController.tableView)
+
+        let now = Int(Date().timeIntervalSince1970)
+
+        // Existing state: only today's section, with the separator below the last message
+        chatViewController.appendMessages(messages: [makeMessage(id: 100, timestamp: now - 60, actorId: "bob", inRoom: room, withAccount: activeAccount)])
+
+        let separator = NCChatMessage()
+        separator.messageId = MessageSeparatorTableViewCell.unreadMessagesSeparatorId
+        let lastDateSection = try XCTUnwrap(chatViewController.dateSections.last)
+        chatViewController.messages[lastDateSection]?.append(separator)
+
+        // Force a layout pass so the reload is actually performed (see test above)
+        tableView.reloadData()
+        tableView.layoutIfNeeded()
+        XCTAssertEqual(tableView.numberOfSections, 1)
+
+        // A backlog message from yesterday arrives together with an own message for today,
+        // so yesterday's section shifts today's section (and the separator) by one
+        let backlogMessage = makeMessage(id: 99, timestamp: now - 86400, actorId: "bob", inRoom: room, withAccount: activeAccount)
+        let ownMessage = makeMessage(id: 101, timestamp: now, actorId: activeAccount.userId, inRoom: room, withAccount: activeAccount)
+        let notification = Notification(name: .NCChatControllerDidReceiveChatMessages,
+                                        object: chatViewController.chatController,
+                                        userInfo: ["messages": [backlogMessage, ownMessage]])
+        chatViewController.didReceiveChatMessages(notification: notification)
+
+        let processed = expectation(description: "Processed received messages")
+        DispatchQueue.main.async { processed.fulfill() }
+        wait(for: [processed], timeout: TestConstants.timeoutShort)
+
+        XCTAssertNil(chatViewController.indexPathForUnreadMessageSeparator())
+        XCTAssertEqual(tableView.numberOfSections, 2)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 0), 1)
+        XCTAssertEqual(tableView.numberOfRows(inSection: 1), 2)
+        XCTAssertEqual(chatViewController.message(for: IndexPath(row: 1, section: 1))?.messageId, 101)
     }
 }

--- a/NextcloudTalkTests/Unit/TestBaseRealm.swift
+++ b/NextcloudTalkTests/Unit/TestBaseRealm.swift
@@ -34,6 +34,7 @@ class TestBaseRealm: XCTestCase {
         account.accountId = TestBaseRealm.fakeAccountId
         account.active = true
         account.user = TestConstants.username
+        account.userId = TestConstants.username
         account.server = TestConstants.server
 
         try? realm.transaction {


### PR DESCRIPTION
The idea here is basically:
* When we write a message from the device ourselves, we can already remove the unread separator when adding the temporary message, effectively doing it in the same animation
* When we have a unread separator and we receive message from ourselves (e.g. written from a different device), we now do it in the same update batch and not in a separate one

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
