### PR TITLE
fix: Reference view fixes

### DIFF
--- a/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
@@ -567,9 +567,11 @@ class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, Reactions
 
             self.referencePart.addSubview(referenceView)
 
-            // Only a preference, so a self-sizing reference – a GIF in its own aspect ratio – may be narrower
+            // Only a preference, so a self-sizing reference – a GIF in its own aspect ratio – may be
+            // narrower. Above content hugging (250/251) so a card with little text still fills the
+            // message, and below the GIF's aspect ratio (.defaultHigh) so that one still wins.
             let fillsAvailableWidth = referenceView.rightAnchor.constraint(equalTo: self.referencePart.rightAnchor, constant: -10)
-            fillsAvailableWidth.priority = .defaultLow
+            fillsAvailableWidth.priority = UILayoutPriority(500)
 
             NSLayoutConstraint.activate([
                 referenceView.leftAnchor.constraint(equalTo: self.messageBodyView.leftAnchor),

--- a/NextcloudTalk/Chat/Chat views/References/ReferenceDefaultView.swift
+++ b/NextcloudTalk/Chat/Chat views/References/ReferenceDefaultView.swift
@@ -13,7 +13,7 @@ import Foundation
     @IBOutlet weak var referenceDescription: UITextView!
     @IBOutlet weak var referenceLink: UILabel!
 
-    /// Used until the thumbnail has loaded, and for the placeholder
+    /// Used until the thumbnail has loaded
     private static let defaultAspectRatio: CGFloat = 1.0
 
     /// Keeps room for the text, in place of the nib's minimum width on the text stack – that reserved it
@@ -22,7 +22,7 @@ import Foundation
 
     var url: String?
 
-    private var thumbnailAspectRatioConstraint: NSLayoutConstraint?
+    private var thumbnailWidthConstraint: NSLayoutConstraint?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -80,7 +80,7 @@ import Foundation
             referenceDescription.isHidden = true
             referenceLink.text = url
 
-            setPlaceholderThumbnail()
+            hideThumbnail()
             return
         }
 
@@ -97,7 +97,7 @@ import Foundation
                 guard let self else { return }
 
                 guard error == nil, let image, image.size.width > 0, image.size.height > 0 else {
-                    self.setPlaceholderThumbnail()
+                    self.hideThumbnail()
                     return
                 }
 
@@ -107,28 +107,30 @@ import Foundation
                 self.setThumbnailAspectRatio(image.size.width / image.size.height)
             }
         } else {
-            setPlaceholderThumbnail()
+            hideThumbnail()
         }
     }
 
-    func setPlaceholderThumbnail() {
-        // Tinted against the card fill, not with it: the fills are translucent, so the same colour
-        // would leave the placeholder all but invisible
-        referenceThumbnailView.image = UIImage(systemName: "safari")?.withTintColor(UIColor.secondaryLabel, renderingMode: .alwaysOriginal)
-
-        // A symbol shouldn't be blown up to fill the thumbnail box like a photo would be
-        referenceThumbnailView.contentMode = .scaleAspectFit
-        setThumbnailAspectRatio(Self.defaultAspectRatio)
+    /// Collapses the thumbnail rather than standing a glyph in for it, leaving the reference as text. The
+    /// view stays in place, at no width: the nib pins the text to *its* trailing edge, so removing it
+    /// would leave the text with nothing to hang from. The 10pt gap becomes the text's leading inset,
+    /// matching the trailing side.
+    func hideThumbnail() {
+        referenceThumbnailView.image = nil
+        setThumbnailWidth(referenceThumbnailView.widthAnchor.constraint(equalToConstant: 0))
     }
 
     private func setThumbnailAspectRatio(_ aspectRatio: CGFloat) {
-        thumbnailAspectRatioConstraint?.isActive = false
+        setThumbnailWidth(referenceThumbnailView.widthAnchor.constraint(equalTo: referenceThumbnailView.heightAnchor, multiplier: aspectRatio))
+    }
 
-        // Below the maximum width, so that a panorama-like thumbnail is cropped instead of taking over
-        let constraint = referenceThumbnailView.widthAnchor.constraint(equalTo: referenceThumbnailView.heightAnchor, multiplier: aspectRatio)
+    private func setThumbnailWidth(_ constraint: NSLayoutConstraint) {
+        thumbnailWidthConstraint?.isActive = false
+
+        // Below the required maximum, so a panorama-like thumbnail is cropped instead of taking over
         constraint.priority = .defaultHigh
         constraint.isActive = true
 
-        thumbnailAspectRatioConstraint = constraint
+        thumbnailWidthConstraint = constraint
     }
 }

--- a/NextcloudTalk/Chat/Chat views/References/ReferenceDefaultView.xib
+++ b/NextcloudTalk/Chat/Chat views/References/ReferenceDefaultView.xib
@@ -29,7 +29,7 @@
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillProportionally" translatesAutoresizingMaskIntoConstraints="NO" id="TwV-dN-hY4">
                     <rect key="frame" x="95" y="10" width="510" height="80"/>
                     <subviews>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ReferenceName" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="Iby-r5-06p">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalHuggingPriority="251" text="ReferenceName" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="200" translatesAutoresizingMaskIntoConstraints="NO" id="Iby-r5-06p">
                             <rect key="frame" x="0.0" y="0.0" width="510" height="20"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="JQE-Y4-q6k"/>
@@ -50,12 +50,12 @@
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                         </textView>
-                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ReferenceLink" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ya-yo-pxr">
+                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalHuggingPriority="251" text="ReferenceLink" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3ya-yo-pxr">
                             <rect key="frame" x="0.0" y="60" width="510" height="20"/>
                             <constraints>
                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="20" id="QNn-28-pgu"/>
                             </constraints>
-                            <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                             <color key="textColor" systemColor="linkColor"/>
                             <nil key="highlightedColor"/>
                         </label>

--- a/NextcloudTalk/Chat/Chat views/References/ReferenceGiphyView.swift
+++ b/NextcloudTalk/Chat/Chat views/References/ReferenceGiphyView.swift
@@ -16,6 +16,11 @@ import SDWebImage
     /// once loaded – the two don't always agree.
     var aspectRatioHandler: ((CGFloat) -> Void)?
 
+    /// Reports that the GIF itself has finished loading, successfully or not. Unlike every other kind of
+    /// reference, this one is not done when `update(for:and:)` returns – the card is already in the right
+    /// shape by then, but still empty – so the reference view keeps its indicator up until this fires.
+    var loadCompletionHandler: (() -> Void)?
+
     private var url: String?
     private var imageAspectRatioConstraint: NSLayoutConstraint?
 
@@ -79,6 +84,7 @@ import SDWebImage
               let proxiedUrl = URL(string: proxiedUrlString)
         else {
             self.imageView.image = nil
+            self.loadCompletionHandler?()
             return
         }
 
@@ -87,7 +93,12 @@ import SDWebImage
                                    options: [],
                                    context: NCAPIController.sharedInstance().giphyReferenceImageContext,
                                    progress: nil) { [weak self] image, _, _, _ in
-            guard let self, let image, image.size.width > 0, image.size.height > 0 else { return }
+            guard let self else { return }
+
+            // Reported before the size check, as a GIF that failed to load leaves nothing more to wait for
+            self.loadCompletionHandler?()
+
+            guard let image, image.size.width > 0, image.size.height > 0 else { return }
 
             // The loaded GIF is the authority – the renditions the reference lists don't always match
             // it, and any difference shows up as the GIF not filling the card

--- a/NextcloudTalk/Chat/Chat views/References/ReferenceView.swift
+++ b/NextcloudTalk/Chat/Chat views/References/ReferenceView.swift
@@ -22,6 +22,10 @@ class ReferenceView: UIView {
 
     private var aspectRatioConstraint: NSLayoutConstraint?
 
+    /// The GIF whose load the indicator is waiting on. A load can outlive the card that started it – by
+    /// then the cell may be showing another message – so its reports are matched against this first.
+    private weak var currentGiphyView: ReferenceGiphyView?
+
     /// Sizes the card to an aspect ratio rather than letting it stretch across the message, or restores
     /// the full width when passed nil. Only the GIF uses this – card beside a GIF is just empty fill.
     func setAspectRatio(_ aspectRatio: CGFloat?) {
@@ -60,6 +64,18 @@ class ReferenceView: UIView {
 
         activityIndicatorView.addSubview(activityIndicator)
 
+        // The nib holds this at a fixed inset from the leading edge, which only ever looked centred
+        // because the card was full width whenever it showed. A GIF keeps it up at its own aspect ratio,
+        // where that inset puts it off to one side and past the clipping bounds.
+        activityIndicatorView.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            activityIndicatorView.centerXAnchor.constraint(equalTo: contentView.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            activityIndicatorView.widthAnchor.constraint(equalToConstant: activityIndicator.frame.width),
+            activityIndicatorView.heightAnchor.constraint(equalToConstant: activityIndicator.frame.height)
+        ])
+
         layer.cornerRadius = 8.0
         layer.masksToBounds = true
 
@@ -70,6 +86,7 @@ class ReferenceView: UIView {
 
     func prepareForReuse() {
         referenceView.subviews.forEach({ $0.removeFromSuperview() })
+        currentGiphyView = nil
         setAspectRatio(nil)
         showIndicatorView()
     }
@@ -94,6 +111,7 @@ class ReferenceView: UIView {
     }
 
     func update(for sharedDeckCard: NCDeckCardParameter) {
+        currentGiphyView = nil
         setAspectRatio(nil)
 
         let deckView = ReferenceDeckView(frame: self.frame)
@@ -107,6 +125,7 @@ class ReferenceView: UIView {
 
     func update(for references: [String: [String: AnyObject]]?, and url: String) {
         referenceView.subviews.forEach({ $0.removeFromSuperview() })
+        currentGiphyView = nil
 
         // Every kind but the GIF fills the width; that branch asks for its own shape again below
         setAspectRatio(nil)
@@ -125,6 +144,7 @@ class ReferenceView: UIView {
         let richObjectType = firstReference["richObjectType"] as? String
 
         var foundReferenceView = false
+        var deferredIndicator = false
 
         if richObjectType == "integration_github" || richObjectType == "integration_github_issue_pr",
            let reference = firstReference["richObject"] as? [String: AnyObject] {
@@ -181,10 +201,23 @@ class ReferenceView: UIView {
                   let reference = firstReference["richObject"] as? [String: AnyObject] {
 
             let giphyView = ReferenceGiphyView(frame: self.frame)
+            self.currentGiphyView = giphyView
 
-            // Set before updating, as that already reports the aspect ratio the reference claims
-            giphyView.aspectRatioHandler = { [weak self] aspectRatio in
-                self?.setAspectRatio(aspectRatio)
+            // The GIF still has to load, so this branch owns the indicator from here on
+            deferredIndicator = true
+
+            // Both are set before updating, as that already reports the aspect ratio the reference claims,
+            // and a cached GIF reports its load from inside that call too
+            giphyView.aspectRatioHandler = { [weak self, weak giphyView] aspectRatio in
+                guard let self, let giphyView, giphyView === self.currentGiphyView else { return }
+
+                self.setAspectRatio(aspectRatio)
+            }
+
+            giphyView.loadCompletionHandler = { [weak self, weak giphyView] in
+                guard let self, let giphyView, giphyView === self.currentGiphyView else { return }
+
+                self.hideIndicatorView()
             }
 
             giphyView.update(for: reference, and: url)
@@ -208,6 +241,8 @@ class ReferenceView: UIView {
             showErrorView(for: url)
         }
 
-        hideIndicatorView()
+        if !deferredIndicator {
+            hideIndicatorView()
+        }
     }
 }


### PR DESCRIPTION
* Ensure the activity indicator is inside the view (currently it is constraint to the left with a fixed size)
* Ensure the activity indicator is visible for gifs
* Adjust the url font to be identical to description again
* Prevent the reference view from shrinking (only allowed for gifs

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
