### PR TITLE
feat: Glass text input

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -266,7 +266,7 @@ import Toast
         self.isInverted = false
 
         self.showSendMessageButton()
-        self.leftButton.setImage(UIImage(systemName: "plus"), for: .normal)
+        self.setInputbarImage(UIImage(systemName: "plus"), for: self.leftButton)
         self.leftButton.accessibilityLabel = NSLocalizedString("Share a file from your Nextcloud", comment: "")
         self.leftButton.accessibilityHint = NSLocalizedString("Double tap to open file browser", comment: "")
         self.leftButton.accessibilityIdentifier = "shareButton"
@@ -736,9 +736,9 @@ import Toast
         self.rightButton.setTitle("", for: .normal)
 
         if self.room.hasScheduledMessages {
-            self.rightButton.setImage(UIImage(systemName: "clock"), for: .normal)
+            self.setInputbarImage(UIImage(systemName: "clock"), for: self.rightButton)
         } else {
-            self.rightButton.setImage(UIImage(systemName: "mic"), for: .normal)
+            self.setInputbarImage(UIImage(systemName: "mic"), for: self.rightButton)
         }
 
         self.rightButton.tag = sendButtonTagVoice
@@ -750,7 +750,7 @@ import Toast
 
     func showSendMessageButton() {
         self.rightButton.setTitle("", for: .normal)
-        self.rightButton.setImage(UIImage(systemName: "paperplane"), for: .normal)
+        self.setInputbarImage(UIImage(systemName: "paperplane"), for: self.rightButton)
         self.rightButton.tag = sendButtonTagMessage
         self.rightButton.accessibilityLabel = NSLocalizedString("Send message", comment: "")
         self.rightButton.accessibilityHint = NSLocalizedString("Double tap to send message", comment: "")
@@ -2374,7 +2374,7 @@ import Toast
             self.longPressStartingPoint = point
             self.cancelHintLabelInitialPositionX = voiceMessageRecordingView?.slideToCancelHintLabel?.frame.origin.x
             self.voiceRecordingLockButton.alpha = 1
-            self.rightButton.setImage(UIImage(systemName: "mic"), for: .normal)
+            self.setInputbarImage(UIImage(systemName: "mic"), for: self.rightButton)
         } else if gestureRecognizer.state == .ended {
             self.shouldLockInterfaceOrientation(lock: false)
             self.resetVoiceRecordingLockButton()

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -101,7 +101,6 @@ import Toast
     private var voiceMessageRecordingView: VoiceMessageRecordingView?
     private var expandedUIHostingController: UIHostingController<ExpandedVoiceMessageRecordingView>?
     private var longPressStartingPoint: CGPoint?
-    private var cancelHintLabelInitialPositionX: CGFloat?
     private var recordCancelled: Bool = false
 
     private var animationDispatchGroup = DispatchGroup()
@@ -1934,6 +1933,26 @@ import Toast
         self.textInputbar.addSubview(voiceMessageRecordingView)
         self.textInputbar.bringSubviewToFront(voiceMessageRecordingView)
 
+        if self.hasGlassInputbar, #available(iOS 26.0, *) {
+            // Recording gets a glass capsule of its own, taking the place of the attachment button and the
+            // input field. The field capsule alone is too narrow for the recording time and the hint.
+            voiceMessageRecordingView.useGlassBackground(cornerRadius: self.textViewBackgroundView?.layer.cornerRadius ?? 22)
+
+            // Only one glass shape at a time, and the placeholder of the textView would shine through
+            self.textViewBackgroundView?.alpha = 0
+            self.textView.isHidden = true
+            self.leftButton.alpha = 0
+
+            NSLayoutConstraint.activate([
+                voiceMessageRecordingView.leadingAnchor.constraint(equalTo: self.leftButton.leadingAnchor),
+                voiceMessageRecordingView.trailingAnchor.constraint(equalTo: self.textView.trailingAnchor),
+                voiceMessageRecordingView.topAnchor.constraint(equalTo: self.textView.topAnchor),
+                voiceMessageRecordingView.bottomAnchor.constraint(equalTo: self.textView.bottomAnchor)
+            ])
+
+            return
+        }
+
         let views = [
             "voiceMessageRecordingView": voiceMessageRecordingView
         ]
@@ -1947,6 +1966,10 @@ import Toast
     }
 
     func hideVoiceMessageRecordingView() {
+        self.textView.isHidden = false
+        self.textViewBackgroundView?.alpha = 1
+        self.leftButton.alpha = 1
+
         self.voiceMessageRecordingView?.isHidden = true
         self.voiceMessageRecordingView?.removeFromSuperview()
         self.voiceMessageRecordingView?.stopTimeLabelTimer()
@@ -2378,7 +2401,6 @@ import Toast
             self.shouldLockInterfaceOrientation(lock: true)
             self.recordCancelled = false
             self.longPressStartingPoint = point
-            self.cancelHintLabelInitialPositionX = voiceMessageRecordingView?.slideToCancelHintLabel?.frame.origin.x
             self.voiceRecordingLockButton.alpha = 1
             self.setInputbarImage(UIImage(systemName: "mic"), for: self.rightButton)
         } else if gestureRecognizer.state == .ended {
@@ -2395,7 +2417,6 @@ import Toast
             }
         } else if gestureRecognizer.state == .changed {
             guard let longPressStartingPoint,
-                  let cancelHintLabelInitialPositionX,
                   let voiceMessageRecordingView,
                   let slideToCancelHintLabel = voiceMessageRecordingView.slideToCancelHintLabel
             else { return }
@@ -2406,11 +2427,10 @@ import Toast
             // Only slide view to the left
             if slideX > 0 {
                 let maxSlideX = 100.0
-                var labelFrame = slideToCancelHintLabel.frame
-                labelFrame = .init(x: cancelHintLabelInitialPositionX - slideX, y: labelFrame.origin.y, width: labelFrame.size.width, height: labelFrame.size.height)
 
-                slideToCancelHintLabel.frame = labelFrame
-                slideToCancelHintLabel.alpha = (maxSlideX - slideX) / 100
+                // Moved with a transform, as the hint is laid out by auto layout now
+                slideToCancelHintLabel.transform = CGAffineTransform(translationX: -slideX, y: 0)
+                slideToCancelHintLabel.alpha = max(0, (maxSlideX - slideX) / maxSlideX)
 
                 // Cancel recording if slided more than maxSlideX
                 if slideX > maxSlideX, !self.recordCancelled, !isVoiceRecordingLocked {

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -365,6 +365,12 @@ import Toast
         return tableView.contentSize.height + tableView.adjustedContentInset.bottom - tableView.frame.size.height
     }
 
+    /// The animation to use when inserting new messages at the bottom of the chat. When the chat extends behind the
+    /// textInputbar, the insert animation is no longer clipped at the bar and competes with the scroll to the bottom.
+    internal var newMessageRowAnimation: UITableView.RowAnimation {
+        return self.scrollViewExtendsBehindTextInputbar ? .none : .automatic
+    }
+
     public func updateToolbar(animated: Bool) {
         guard let tableView else { return }
 

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -358,11 +358,23 @@ import Toast
         self.updateToolbar(animated: true)
     }
 
+    /// The content offset at which the tableView is scrolled all the way down, taking the space reserved for the textInputbar into account
+    internal var tableViewBottomContentOffset: CGFloat {
+        guard let tableView else { return 0 }
+
+        return tableView.contentSize.height + tableView.adjustedContentInset.bottom - tableView.frame.size.height
+    }
+
     public func updateToolbar(animated: Bool) {
         guard let tableView else { return }
 
         let animations = {
-            let minimumOffset = (tableView.contentSize.height - tableView.frame.size.height) - 10
+            // Since iOS 26 the content scrolls behind the transparent textInputbar, so there's no border to show
+            if #available(iOS 26.0, *) {
+                return
+            }
+
+            let minimumOffset = self.tableViewBottomContentOffset - 10
 
             if tableView.contentOffset.y < minimumOffset {
                 // Scrolled -> show top border
@@ -385,7 +397,7 @@ import Toast
         }
 
         let animationsScrollButton = {
-            let minimumOffset = (tableView.contentSize.height - tableView.frame.size.height) - 10
+            let minimumOffset = self.tableViewBottomContentOffset - 10
 
             if tableView.contentOffset.y < minimumOffset {
                 // Scrolled -> show button
@@ -402,11 +414,16 @@ import Toast
                 self.animationDispatchGroup.enter()
 
                 DispatchQueue.main.async {
-                    UIView.transition(with: self.textInputbar,
-                                      duration: 0.3,
-                                      options: .transitionCrossDissolve,
-                                      animations: animations) { _ in
+                    if #available(iOS 26.0, *) {
+                        // Nothing to animate in the textInputbar, so don't cross-dissolve the glass elements
                         self.animationDispatchGroup.leave()
+                    } else {
+                        UIView.transition(with: self.textInputbar,
+                                          duration: 0.3,
+                                          options: .transitionCrossDissolve,
+                                          animations: animations) { _ in
+                            self.animationDispatchGroup.leave()
+                        }
                     }
                 }
 
@@ -3681,7 +3698,7 @@ import Toast
         guard self.isVisible, let tableView = self.tableView else { return false }
 
         // Scroll if table view is at the bottom (or 80px up)
-        let minimumOffset = (tableView.contentSize.height - tableView.frame.size.height) - 80
+        let minimumOffset = self.tableViewBottomContentOffset - 80
 
         if tableView.contentOffset.y >= minimumOffset {
             return true
@@ -3892,8 +3909,9 @@ import Toast
         // ContentOffset when the cell is at the top of the tableView
         let contentOffsetTop = rect.origin.y - tableView.safeAreaInsets.top
 
-        // ContentOffset when the cell is at the middle of the tableView
-        let contentOffsetMiddle = contentOffsetTop - tableView.frame.height / 2 + rect.height / 2
+        // ContentOffset when the cell is at the middle of the visible part of the tableView
+        let visibleHeight = tableView.frame.height - tableView.adjustedContentInset.bottom
+        let contentOffsetMiddle = contentOffsetTop - visibleHeight / 2 + rect.height / 2
 
         // Fallback to the top offset in case the top of the cell would be scrolled outside of the view
         let newContentOffset = min(contentOffsetTop, contentOffsetMiddle)

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -265,10 +265,7 @@ import Toast
         self.isInverted = false
 
         self.showSendMessageButton()
-        self.setInputbarImage(UIImage(systemName: "plus"), for: self.leftButton)
-        self.leftButton.accessibilityLabel = NSLocalizedString("Share a file from your Nextcloud", comment: "")
-        self.leftButton.accessibilityHint = NSLocalizedString("Double tap to open file browser", comment: "")
-        self.leftButton.accessibilityIdentifier = "shareButton"
+        self.showAttachmentButton()
 
         // Add LongPressRecognizer to allow showing photo picker directly
         let longPressRecognizer = UILongPressGestureRecognizer(target: self, action: #selector(longPress(gestureRecognizer:)))
@@ -753,6 +750,13 @@ import Toast
         self.addGestureRecognizerToRightButton()
     }
 
+    func showAttachmentButton() {
+        self.setInputbarImage(UIImage(systemName: "plus"), for: self.leftButton)
+        self.leftButton.accessibilityLabel = NSLocalizedString("Share a file from your Nextcloud", comment: "")
+        self.leftButton.accessibilityHint = NSLocalizedString("Double tap to open file browser", comment: "")
+        self.leftButton.accessibilityIdentifier = "shareButton"
+    }
+
     func showSendMessageButton() {
         self.rightButton.setTitle("", for: .normal)
         self.setInputbarImage(UIImage(systemName: "paperplane"), for: self.rightButton)
@@ -826,7 +830,21 @@ import Toast
         self.stopTyping(force: true)
     }
 
+    public override func didPressLeftButton(_ sender: Any?) {
+        if self.textInputbar.isEditing {
+            self.didCancelTextEditing(sender as Any)
+            return
+        }
+
+        super.didPressLeftButton(sender)
+    }
+
     public override func didPressRightButton(_ sender: Any?) {
+        if self.textInputbar.isEditing {
+            self.didCommitTextEditing(sender as Any)
+            return
+        }
+
         guard let button = sender as? UIButton else { return }
 
         switch button.tag {
@@ -1520,6 +1538,12 @@ import Toast
         self.editingMessage = nil
         self.restorePendingMessage()
         self.stopTyping(force: true)
+        self.updateInputbarButtonsForEditing()
+    }
+
+    public override func editAttributedText(_ attributedText: NSAttributedString) {
+        super.editAttributedText(attributedText)
+        self.updateInputbarButtonsForEditing()
     }
 
     public override func didCancelTextEditing(_ sender: Any) {
@@ -1530,6 +1554,36 @@ import Toast
     public override func didCommitTextEditing(_ sender: Any) {
         super.didCommitTextEditing(sender)
         self.didEndTextEditing()
+    }
+
+    /// Lets the buttons next to the input field cancel and save an edited message, since the glass inputbar
+    /// does not show the editor row of SLKTextInputbar anymore.
+    internal func updateInputbarButtonsForEditing() {
+        guard self.hasGlassInputbar else { return }
+
+        if self.textInputbar.isEditing {
+            // The attachment menu is the primary action of the left button, so no press is reported while it's set
+            self.leftButton.menu = nil
+            self.leftButton.showsMenuAsPrimaryAction = false
+            self.leftButtonLongPressGesture?.isEnabled = false
+
+            self.setInputbarImage(UIImage(systemName: "xmark"), for: self.leftButton)
+            self.leftButton.accessibilityLabel = NSLocalizedString("Cancel", comment: "")
+            self.leftButton.accessibilityHint = NSLocalizedString("Double tap to discard the changes", comment: "")
+
+            self.setInputbarImage(UIImage(systemName: "checkmark"), for: self.rightButton)
+            self.rightButton.accessibilityLabel = NSLocalizedString("Save changes", comment: "")
+            self.rightButton.accessibilityHint = NSLocalizedString("Double tap to save the edited message", comment: "")
+        } else {
+            self.leftButtonLongPressGesture?.isEnabled = true
+            self.showAttachmentButton()
+            self.addMenuToLeftButton()
+
+            // Both buttons are set up from scratch instead of being restored: showAttachmentButton() knows
+            // about federation, and canPressRightButton() about send or record for the text we have now
+            self.showSendMessageButton()
+            self.textDidUpdate(false)
+        }
     }
 
     // MARK: - UITextField delegate
@@ -2387,6 +2441,11 @@ import Toast
 
     func handleLongPressInVoiceMessageRecordButton(gestureRecognizer: UILongPressGestureRecognizer) {
         if self.rightButton.tag != sendButtonTagVoice {
+            return
+        }
+
+        // While editing, the button saves the message instead
+        if self.textInputbar.isEditing {
             return
         }
 

--- a/NextcloudTalk/Chat/Chat views/ReplyMessageView.swift
+++ b/NextcloudTalk/Chat/Chat views/ReplyMessageView.swift
@@ -7,7 +7,16 @@ import UIKit
 
 @objcMembers class ReplyMessageView: UIView, SLKVisibleViewProtocol {
 
-    dynamic var isVisible: Bool = false
+    dynamic var isVisible: Bool = false {
+        didSet {
+            guard isVisible != oldValue else { return }
+
+            // Fade along with the height animation of the SLKTextViewController, our content does not shrink
+            UIView.animate(withDuration: 0.2, delay: 0, options: [.curveEaseInOut, .beginFromCurrentState]) {
+                self.alpha = self.isVisible ? 1 : 0
+            }
+        }
+    }
 
     var message: NCChatMessage?
 
@@ -65,6 +74,9 @@ import UIKit
     }
 
     private func configureSubviews() {
+        // We start out hidden, so the first presentation fades in
+        alpha = 0
+
         addSubview(quoteContainerView)
         addSubview(cancelButton)
 

--- a/NextcloudTalk/Chat/Chat views/ReplyMessageView.swift
+++ b/NextcloudTalk/Chat/Chat views/ReplyMessageView.swift
@@ -45,6 +45,16 @@ import UIKit
 
     private var cancelButtonWidthConstraint: NSLayoutConstraint!
 
+    /// Glass background, only used on iOS 26 and above
+    private var backgroundView: UIVisualEffectView?
+
+    /// Corner radius of the glass background, set by the InputbarViewController to match the textView below
+    internal var backgroundCornerRadius: CGFloat = 22 {
+        didSet {
+            backgroundView?.layer.cornerRadius = backgroundCornerRadius
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         configureSubviews()
@@ -55,13 +65,45 @@ import UIKit
     }
 
     private func configureSubviews() {
-        backgroundColor = .systemBackground
-
         addSubview(quoteContainerView)
         addSubview(cancelButton)
-        layer.addSublayer(topBorder)
+
+        if #available(iOS 26.0, *) {
+            // The chat content scrolls behind the reply view, so it needs its own glass background
+            let backgroundView = UIVisualEffectView(effect: UIGlassEffect())
+            backgroundView.translatesAutoresizingMaskIntoConstraints = false
+            backgroundView.isUserInteractionEnabled = false
+            backgroundView.clipsToBounds = true
+            backgroundView.layer.cornerCurve = .continuous
+            backgroundView.layer.cornerRadius = backgroundCornerRadius
+
+            insertSubview(backgroundView, at: 0)
+            self.backgroundView = backgroundView
+
+            NSLayoutConstraint.activate([
+                backgroundView.leadingAnchor.constraint(equalTo: safeAreaLayoutGuide.leadingAnchor, constant: 8),
+                backgroundView.trailingAnchor.constraint(equalTo: safeAreaLayoutGuide.trailingAnchor, constant: -8),
+                backgroundView.topAnchor.constraint(equalTo: topAnchor, constant: 4),
+                backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -4)
+            ])
+        } else {
+            backgroundColor = .systemBackground
+            layer.addSublayer(topBorder)
+        }
 
         quoteContainerView.addSubview(quotedMessageView)
+
+        // The glass background provides the frame, so the quoted message itself stays chrome-less. Only done for
+        // our own instance, the one inside a chat bubble keeps its border.
+        var cancelButtonRightInset: CGFloat = -4
+
+        if #available(iOS 26.0, *) {
+            quotedMessageView.layer.borderWidth = 0
+            quotedMessageView.layer.cornerRadius = 0
+
+            // Keep the cancel button inside the glass background
+            cancelButtonRightInset = -12
+        }
 
         cancelButtonWidthConstraint = cancelButton.widthAnchor.constraint(equalToConstant: 44)
 
@@ -70,7 +112,7 @@ import UIKit
 
             cancelButton.leftAnchor.constraint(equalTo: quoteContainerView.rightAnchor, constant: 4),
 
-            cancelButton.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: -4),
+            cancelButton.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor, constant: cancelButtonRightInset),
             cancelButtonWidthConstraint,
             quotedMessageView.widthAnchor.constraint(equalTo: quoteContainerView.widthAnchor),
 

--- a/NextcloudTalk/Chat/Chat views/VoiceMessageRecordingView.swift
+++ b/NextcloudTalk/Chat/Chat views/VoiceMessageRecordingView.swift
@@ -16,6 +16,16 @@ class VoiceMessageRecordingView: UIView {
     private weak var labelTimer: Timer?
     private var startTimestamp = 0
 
+    /// Clips the hint while it slides to the left, so it disappears behind the recording time
+    private lazy var hintContainerView: UIView = {
+        let hintContainerView = UIView()
+        hintContainerView.translatesAutoresizingMaskIntoConstraints = false
+        hintContainerView.backgroundColor = .clear
+        hintContainerView.clipsToBounds = true
+
+        return hintContainerView
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         commonInit()
@@ -31,22 +41,104 @@ class VoiceMessageRecordingView: UIView {
 
         addSubview(contentView)
 
-        contentView.frame = bounds
-
         contentView.backgroundColor = .systemBackground
-        leftBackgroundView.backgroundColor = .systemBackground
 
+        setupLayout()
         startTimeLabelTimer()
 
         recordingImageView.image = UIImage(systemName: "mic.fill")
         recordingImageView.tintColor = .systemRed
         recordingImageView.contentMode = .scaleAspectFit
-        UIView.animate(withDuration: 0.5, delay: 0, options: [.repeat, .autoreverse]) {
-            self.recordingImageView.alpha = 0
-        }
 
         let swipeToCancelString = NSLocalizedString("Slide to cancel", comment: "")
         slideToCancelHintLabel.text = "<< \(swipeToCancelString)"
+    }
+
+    /// Pulses the microphone with a layer animation. A UIView animation would set the alpha of the view itself
+    /// to zero, leaving the microphone invisible whenever the animation is removed.
+    private func startPulseAnimation() {
+        let pulseAnimation = CABasicAnimation(keyPath: "opacity")
+        pulseAnimation.fromValue = 1
+        pulseAnimation.toValue = 0
+        pulseAnimation.duration = 0.5
+        pulseAnimation.autoreverses = true
+        pulseAnimation.repeatCount = .infinity
+
+        recordingImageView.layer.add(pulseAnimation, forKey: "pulse")
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+
+        // Animations are removed while a layer is outside of the render tree
+        if window != nil, recordingImageView.layer.animation(forKey: "pulse") == nil {
+            startPulseAnimation()
+        }
+    }
+
+    /// The xib places its subviews with fixed frames, made for an inputbar of a fixed height. Lay them out
+    /// instead, so they fit whatever size this view is given.
+    private func setupLayout() {
+        // The xib does not use auto layout: its frames would win over the constraints below
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        recordingImageView.translatesAutoresizingMaskIntoConstraints = false
+        recordingTimeLabel.translatesAutoresizingMaskIntoConstraints = false
+        slideToCancelHintLabel.translatesAutoresizingMaskIntoConstraints = false
+
+        contentView.addSubview(hintContainerView)
+        hintContainerView.addSubview(slideToCancelHintLabel)
+
+        // The hint is the only one to truncate when there is not enough room
+        slideToCancelHintLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        NSLayoutConstraint.activate([
+            contentView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            contentView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            contentView.topAnchor.constraint(equalTo: topAnchor),
+            contentView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            recordingImageView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 16),
+            recordingImageView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+            recordingImageView.widthAnchor.constraint(equalToConstant: 26),
+            recordingImageView.heightAnchor.constraint(equalToConstant: 26),
+
+            recordingTimeLabel.leadingAnchor.constraint(equalTo: recordingImageView.trailingAnchor, constant: 8),
+            recordingTimeLabel.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            hintContainerView.leadingAnchor.constraint(greaterThanOrEqualTo: recordingTimeLabel.trailingAnchor, constant: 8),
+            hintContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -16),
+            hintContainerView.centerYAnchor.constraint(equalTo: contentView.centerYAnchor),
+
+            slideToCancelHintLabel.leadingAnchor.constraint(equalTo: hintContainerView.leadingAnchor),
+            slideToCancelHintLabel.trailingAnchor.constraint(equalTo: hintContainerView.trailingAnchor),
+            slideToCancelHintLabel.topAnchor.constraint(equalTo: hintContainerView.topAnchor),
+            slideToCancelHintLabel.bottomAnchor.constraint(equalTo: hintContainerView.bottomAnchor)
+        ])
+
+        // The hint is clipped by its container now, so it doesn't need to slide behind an opaque view anymore
+        leftBackgroundView.isHidden = true
+    }
+
+    /// Gives the recording view a glass capsule of its own, so it can take the place of the input field
+    @available(iOS 26.0, *)
+    public func useGlassBackground(cornerRadius: CGFloat) {
+        contentView.backgroundColor = .clear
+
+        let backgroundView = UIVisualEffectView(effect: UIGlassEffect())
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.isUserInteractionEnabled = false
+        backgroundView.clipsToBounds = true
+        backgroundView.layer.cornerCurve = .continuous
+        backgroundView.layer.cornerRadius = cornerRadius
+
+        contentView.insertSubview(backgroundView, at: 0)
+
+        NSLayoutConstraint.activate([
+            backgroundView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+            backgroundView.topAnchor.constraint(equalTo: contentView.topAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor)
+        ])
     }
 
     private func startTimeLabelTimer() {

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -644,7 +644,7 @@ import SwiftUI
         if room.isFederated {
             // When hiding the button it is still respected in the layout constraints
             // So we need to remove the image to remove the button for now
-            self.leftButton.setImage(nil, for: .normal)
+            self.setInputbarImage(nil, for: self.leftButton)
         }
 
         // Disable room info, input bar and call buttons until joining room

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -1711,11 +1711,11 @@ import SwiftUI
                 } else {
                     tableView.performBatchUpdates {
                         if !update.insertSections.isEmpty {
-                            tableView.insertSections(update.insertSections, with: .automatic)
+                            tableView.insertSections(update.insertSections, with: self.newMessageRowAnimation)
                         }
 
                         if !update.insertIndexPaths.isEmpty {
-                            tableView.insertRows(at: Array(update.insertIndexPaths), with: .automatic)
+                            tableView.insertRows(at: Array(update.insertIndexPaths), with: self.newMessageRowAnimation)
                         }
 
                         if !update.reloadIndexPaths.isEmpty {

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -640,13 +640,6 @@ import SwiftUI
 
         self.navigationItem.rightBarButtonItems = barButtonsItems
 
-        // No sharing options in federation v1 (or thread view until implemented)
-        if room.isFederated {
-            // When hiding the button it is still respected in the layout constraints
-            // So we need to remove the image to remove the button for now
-            self.setInputbarImage(nil, for: self.leftButton)
-        }
-
         // Disable room info, input bar and call buttons until joining room
         self.disableRoomControls()
     }
@@ -823,6 +816,23 @@ import SwiftUI
 
     // MARK: - User Interface
 
+    override func showAttachmentButton() {
+        super.showAttachmentButton()
+
+        // No sharing options in federation v1 (or thread view until implemented). When hiding the button it is
+        // still respected in the layout constraints, so we need to remove the image to remove the button for now
+        if room.isFederated {
+            self.setInputbarImage(nil, for: self.leftButton)
+        }
+    }
+
+    override func updateInputbarButtonsForEditing() {
+        super.updateInputbarButtonsForEditing()
+
+        // Whether the buttons can be used depends on the room and the connection, not on what they do
+        self.checkRoomControlsAvailability()
+    }
+
     func disableRoomControls() {
         self.titleView?.isUserInteractionEnabled = false
 
@@ -840,8 +850,9 @@ import SwiftUI
             self.callOptionsButton.isEnabled = true
         }
 
-        // Files/objects can only be send when we're not offline
-        self.leftButton.isEnabled = !offlineMode
+        // Files/objects can only be send when we're not offline. While editing the button cancels it instead,
+        // which has to stay possible.
+        self.leftButton.isEnabled = !offlineMode || self.textInputbar.isEditing
 
         // Always allow to start writing a message, even if we didn't join the room (yet)
         self.rightButton.isEnabled = self.canPressRightButton()

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -25,6 +25,11 @@ import UIKit
     /// Glass background of the textView, only used on iOS 26 and above
     internal var textViewBackgroundView: UIVisualEffectView?
 
+    /// Whether the inputbar uses the glass appearance (iOS 26 and above)
+    internal var hasGlassInputbar: Bool {
+        return self.textViewBackgroundView != nil
+    }
+
     public var isThreadViewController: Bool {
         return thread != nil
     }

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -259,6 +259,11 @@ import UIKit
             self.textInputbar.addInteraction(scrollEdgeInteraction)
         }
 
+        // Editing happens in the inputbar itself, a second row on top of the glass elements would look like an
+        // unrelated bar (see BaseChatViewController.updateInputbarButtonsForEditing)
+        self.textInputbar.keepsButtonsWhileEditing = true
+        self.textInputbar.editorContentViewHeight = 0
+
         // Glass background for the textView
         self.textViewBackgroundView = self.addGlassBackgroundView(behind: self.textView)
 

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -22,6 +22,11 @@ import UIKit
     internal var contentView: UIView?
     internal var selectedAutocompletionRow: IndexPath?
 
+    /// Glass backgrounds of the textView and the inputbar buttons, only used on iOS 26 and above
+    internal var textViewBackgroundView: UIVisualEffectView?
+    internal var leftButtonBackgroundView: UIVisualEffectView?
+    internal var rightButtonBackgroundView: UIVisualEffectView?
+
     public var isThreadViewController: Bool {
         return thread != nil
     }
@@ -141,11 +146,16 @@ import UIKit
 
         self.view.backgroundColor = .systemBackground
         self.tableView?.backgroundColor = .systemBackground
-        self.textInputbar.backgroundColor = .systemBackground
 
         self.textInputbar.editorTitle.textColor = .label
-        self.textView.layer.borderWidth = 1.0
-        self.textView.layer.borderColor = UIColor.systemGray4.cgColor
+
+        if #available(iOS 26.0, *) {
+            self.setupGlassInputbar()
+        } else {
+            self.textInputbar.backgroundColor = .systemBackground
+            self.textView.layer.borderWidth = 1.0
+            self.textView.layer.borderColor = UIColor.systemGray4.cgColor
+        }
 
         self.textView.delegate = self
 
@@ -174,10 +184,21 @@ import UIKit
         self.restorePendingMessage()
     }
 
+    public override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+
+        if #available(iOS 26.0, *) {
+            self.updateInputbarCornerRadius()
+        }
+    }
+
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         if self.traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) {
             // We use a CGColor so we loose the automatic color changing of dynamic colors -> update manually
-            self.textView.layer.borderColor = UIColor.systemGray4.cgColor
+            if #unavailable(iOS 26.0) {
+                self.textView.layer.borderColor = UIColor.systemGray4.cgColor
+            }
+
             self.textView.tintColor = UIColor(cgColor: UIColor.systemBlue.cgColor)
 
             self.setTitleView()
@@ -185,6 +206,105 @@ import UIKit
             // When the size class changes, we want to update the title view (e.g. to show/hide subtitle)
             self.setTitleView()
         }
+    }
+
+    // MARK: - Inputbar appearance
+
+    /// Height of the textView with a single line of text, which is also the height of the inputbar buttons
+    @available(iOS 26.0, *)
+    private var singleLineInputHeight: CGFloat {
+        let lineHeight = (self.textView.font ?? .preferredFont(forTextStyle: .body)).lineHeight
+
+        // Keep an accessible touch target, even with a small preferred font size
+        return max(44, ceil(lineHeight) + 16)
+    }
+
+    @available(iOS 26.0, *)
+    private func setupInputbarMetrics() {
+        let lineHeight = (self.textView.font ?? .preferredFont(forTextStyle: .body)).lineHeight
+        let singleLineInputHeight = self.singleLineInputHeight
+
+        // Pad the text container so a single line of text is exactly as high as the buttons next to it.
+        // SLKTextInputbar derives the height of the inputbar from the intrinsicContentSize of the textView
+        // (lineHeight plus the vertical textContainerInset), so the inputbar itself follows automatically.
+        let verticalTextPadding = (singleLineInputHeight - lineHeight) / 2
+        self.textView.textContainerInset = .init(top: verticalTextPadding, left: 8, bottom: verticalTextPadding, right: 8)
+
+        // The buttons are positioned from the minimum (single line) height of the inputbar, so they keep this
+        // height and their bottom alignment when the textView grows to multiple lines
+        self.textInputbar.minimumButtonSize = .init(width: singleLineInputHeight, height: singleLineInputHeight)
+    }
+
+    @available(iOS 26.0, *)
+    private func setupGlassInputbar() {
+        // The textInputbar itself does not have any background, the glass elements below and the scroll edge
+        // effect of the tableView provide the separation from the content scrolling behind it
+        self.textInputbar.backgroundColor = .clear
+
+        self.setupInputbarMetrics()
+
+        // Only the chat itself scrolls behind the textInputbar, a custom contentView (see ThreadCreationViewController)
+        // is still placed on top of it
+        if self.contentView == nil, let tableView = self.tableView {
+            self.scrollViewExtendsBehindTextInputbar = true
+
+            // Ask the system for a scroll edge effect behind the textInputbar, so content scrolling
+            // behind it stays legible
+            let scrollEdgeInteraction = UIScrollEdgeElementContainerInteraction()
+            scrollEdgeInteraction.scrollView = tableView
+            scrollEdgeInteraction.edge = .bottom
+            self.textInputbar.addInteraction(scrollEdgeInteraction)
+        }
+
+        // Glass background for the textView
+        self.textViewBackgroundView = self.addGlassBackgroundView(behind: self.textView)
+
+        self.textView.backgroundColor = .clear
+        self.textView.layer.borderWidth = 0
+        self.textView.layer.cornerCurve = .continuous
+
+        // Glass background for the left and right button.
+        //
+        // Note: We deliberately don't use a glass UIButton.Configuration here. Assigning a configuration
+        // recreates the button's imageView, which SLKTextInputbar observes to size its buttons, so the
+        // buttons would end up without a size and unregistering that observer would crash on dealloc.
+        self.leftButtonBackgroundView = self.addGlassBackgroundView(behind: self.leftButton)
+        self.rightButtonBackgroundView = self.addGlassBackgroundView(behind: self.rightButton)
+    }
+
+    @available(iOS 26.0, *)
+    private func addGlassBackgroundView(behind view: UIView) -> UIVisualEffectView {
+        let backgroundView = UIVisualEffectView(effect: UIGlassEffect())
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.isUserInteractionEnabled = false
+        backgroundView.clipsToBounds = true
+        backgroundView.layer.cornerCurve = .continuous
+
+        self.textInputbar.insertSubview(backgroundView, belowSubview: view)
+
+        NSLayoutConstraint.activate([
+            backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            backgroundView.topAnchor.constraint(equalTo: view.topAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+
+        return backgroundView
+    }
+
+    @available(iOS 26.0, *)
+    private func updateInputbarCornerRadius() {
+        // A capsule while the textView is a single line high, keeping that radius when it grows. Since the
+        // buttons have the same height, all elements of the input area end up with the same radius.
+        let cornerRadius = self.singleLineInputHeight / 2
+
+        self.textView.layer.cornerRadius = cornerRadius
+        self.textViewBackgroundView?.layer.cornerRadius = cornerRadius
+
+        self.leftButtonBackgroundView?.layer.cornerRadius = self.leftButton.frame.size.height / 2
+        self.rightButtonBackgroundView?.layer.cornerRadius = self.rightButton.frame.size.height / 2
+
+        (self.replyProxyView as? ReplyMessageView)?.backgroundCornerRadius = cornerRadius
     }
 
     // MARK: - Configuration

--- a/NextcloudTalk/Chat/InputbarViewController.swift
+++ b/NextcloudTalk/Chat/InputbarViewController.swift
@@ -22,10 +22,8 @@ import UIKit
     internal var contentView: UIView?
     internal var selectedAutocompletionRow: IndexPath?
 
-    /// Glass backgrounds of the textView and the inputbar buttons, only used on iOS 26 and above
+    /// Glass background of the textView, only used on iOS 26 and above
     internal var textViewBackgroundView: UIVisualEffectView?
-    internal var leftButtonBackgroundView: UIVisualEffectView?
-    internal var rightButtonBackgroundView: UIVisualEffectView?
 
     public var isThreadViewController: Bool {
         return thread != nil
@@ -91,7 +89,7 @@ import UIKit
 
         // Set the rightButton early, to allow sizing the textInputbar correctly
         self.rightButton.setTitle("", for: .normal)
-        self.rightButton.setImage(UIImage(systemName: "paperplane"), for: .normal)
+        self.setInputbarImage(UIImage(systemName: "paperplane"), for: self.rightButton)
         self.rightButton.accessibilityLabel = NSLocalizedString("Send message", comment: "")
         self.rightButton.accessibilityHint = NSLocalizedString("Double tap to send message", comment: "")
 
@@ -263,13 +261,34 @@ import UIKit
         self.textView.layer.borderWidth = 0
         self.textView.layer.cornerCurve = .continuous
 
-        // Glass background for the left and right button.
+        // Real glass buttons, so that pressing them and the menus they present morph out of the glass shape
+        // instead of out of their image.
         //
-        // Note: We deliberately don't use a glass UIButton.Configuration here. Assigning a configuration
-        // recreates the button's imageView, which SLKTextInputbar observes to size its buttons, so the
-        // buttons would end up without a size and unregistering that observer would crash on dealloc.
-        self.leftButtonBackgroundView = self.addGlassBackgroundView(behind: self.leftButton)
-        self.rightButtonBackgroundView = self.addGlassBackgroundView(behind: self.rightButton)
+        // Note: Assigning a configuration recreates the imageView of a button, which SLKTextInputbar observes to
+        // size its buttons. So changing an image has to go through setInputbarImage(_:for:) from now on.
+        var buttonConfiguration = UIButton.Configuration.glass()
+        buttonConfiguration.cornerStyle = .capsule
+
+        // Without this the configuration adds padding around the image, which would make the buttons wider
+        // than they are high
+        buttonConfiguration.contentInsets = .zero
+
+        for button in [self.leftButton, self.rightButton] {
+            buttonConfiguration.image = button.image(for: .normal)
+            button.configuration = buttonConfiguration
+        }
+    }
+
+    /// Sets the image of one of the inputbar buttons.
+    ///
+    /// SLKTextInputbar sizes its buttons based on the image set for the normal state, while the configuration
+    /// based buttons we use since iOS 26 render the image of their configuration. So keep both in sync and let
+    /// the inputbar know, since it can't observe the change itself anymore.
+    internal func setInputbarImage(_ image: UIImage?, for button: UIButton) {
+        button.setImage(image, for: .normal)
+        button.configuration?.image = image
+
+        self.textInputbar.invalidateButtonSizes()
     }
 
     @available(iOS 26.0, *)
@@ -280,7 +299,9 @@ import UIKit
         backgroundView.clipsToBounds = true
         backgroundView.layer.cornerCurve = .continuous
 
-        self.textInputbar.insertSubview(backgroundView, belowSubview: view)
+        // Behind all controls of the inputbar: SLKTextInputbar adds the buttons before the textView, so inserting
+        // this below the textView would still cover them
+        self.textInputbar.insertSubview(backgroundView, at: 0)
 
         NSLayoutConstraint.activate([
             backgroundView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
@@ -300,9 +321,6 @@ import UIKit
 
         self.textView.layer.cornerRadius = cornerRadius
         self.textViewBackgroundView?.layer.cornerRadius = cornerRadius
-
-        self.leftButtonBackgroundView?.layer.cornerRadius = self.leftButton.frame.size.height / 2
-        self.rightButtonBackgroundView?.layer.cornerRadius = self.rightButton.frame.size.height / 2
 
         (self.replyProxyView as? ReplyMessageView)?.backgroundCornerRadius = cornerRadius
     }

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1037,6 +1037,9 @@
 "Double tap to change between grid and speaker view" = "Double tap to change between grid and speaker view";
 
 /* No comment provided by engineer. */
+"Double tap to discard the changes" = "Double tap to discard the changes";
+
+/* No comment provided by engineer. */
 "Double tap to dismiss authentication dialog" = "Double tap to dismiss authentication dialog";
 
 /* No comment provided by engineer. */
@@ -1086,6 +1089,9 @@
 
 /* No comment provided by engineer. */
 "Double tap to open file browser" = "Double tap to open file browser";
+
+/* No comment provided by engineer. */
+"Double tap to save the edited message" = "Double tap to save the edited message";
 
 /* No comment provided by engineer. */
 "Double tap to select different audio routes" = "Double tap to select different audio routes";
@@ -2130,6 +2136,9 @@
 
 /* No comment provided by engineer. */
 "Save as draft" = "Save as draft";
+
+/* No comment provided by engineer. */
+"Save changes" = "Save changes";
 
 /* No comment provided by engineer. */
 "Save password" = "Save password";

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -339,9 +339,8 @@ final class UIRoomTest: XCTestCase {
 
         textView.typeText(" Edited")
 
-        // TODO: Should change the lib to have a proper identifier here
         // Save the edit
-        toolbar.buttons["selected"].tap()
+        toolbar.buttons["Save changes"].tap()
 
         // Check if the edit is correct
         messageTextView = tables.textViews["@\(newConversationName) Edited"]


### PR DESCRIPTION
* Requires https://github.com/nextcloud-deps/SlackTextViewController/pull/28
* Draft until required PR is merged

This kind of closes the last non-glass-adjusted component of the text view. 

<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-02 at 11 08 03" src="https://github.com/user-attachments/assets/411607d2-734d-491f-b269-7023fe76ba21" />
<img width="250" alt="Simulator Screenshot - iPhone 17 Pro - 2026-08-02 at 11 08 01" src="https://github.com/user-attachments/assets/3f19e272-35c3-403c-89f8-023e5b57089a" />


- [x] Removing the typing indicator moves the chat
- [x] Messages sometimes seem to "fly-in"
- [x] When editing or lobby is active, the buttons are still visible
- [x] Voice message view looks weird
- [x] Editing a message could be changed to not show a separate row of buttons


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
