### PR TITLE
fix: Force mute handling

### DIFF
--- a/NextcloudTalk/Calls/CallViewController.swift
+++ b/NextcloudTalk/Calls/CallViewController.swift
@@ -2212,7 +2212,7 @@ class CallViewController: UIViewController,
 
     private func presentUnmuteNotPossibleYetNotification() {
         let forceMutedString = NSLocalizedString("Muted by a moderator", comment: "")
-        let cooldownString = NSLocalizedString("You can unmute again in a few seconds", comment: "")
+        let cooldownString = NSLocalizedString("You can enable your microphone again in a few seconds", comment: "")
 
         DispatchQueue.main.async {
             NotificationPresenter.shared().present(title: forceMutedString, subtitle: cooldownString, includedStyle: .dark)

--- a/NextcloudTalk/Calls/CallViewController.swift
+++ b/NextcloudTalk/Calls/CallViewController.swift
@@ -109,6 +109,7 @@ class CallViewController: UIViewController,
     private let reactionViewAnimationDuration = 2.0
     private let reactionViewHidingDuration = 1.0
     private let maxReactionsOnScreen = 5.0
+    private let forceMuteCooldown = 8.0
 
     private var localVideoOriginPosition: CGPoint = .zero
     private var peersInCall: [NCPeerConnection] = []
@@ -134,6 +135,7 @@ class CallViewController: UIViewController,
     private var videoCallUpgrade = false
     private var hangingUp = false
     private var pushToTalkActive = false
+    private var forceMutedUntil = Date.distantPast
     private var isHandRaised = false
     private var proximityState = false
     private var showChatAfterRoomSwitch = false
@@ -1407,6 +1409,9 @@ class CallViewController: UIViewController,
                 self.audioDisabledAtStart = !audioEnabled
                 self.videoDisabledAtStart = !videoEnabled
 
+                // A force mute only applies to the call we are leaving
+                self.forceMutedUntil = .distantPast
+
                 // Forget current call controller
                 self.callController = nil
 
@@ -2132,6 +2137,12 @@ class CallViewController: UIViewController,
     func pushToTalkStart() {
         guard let callController else { return }
 
+        // While being force muted, push to talk must not unmute us either
+        guard !self.isInForceMuteCooldown else {
+            self.presentUnmuteNotPossibleYetNotification()
+            return
+        }
+
         callController.getAudioEnabledState { isEnabled in
             guard !isEnabled else { return }
 
@@ -2165,8 +2176,38 @@ class CallViewController: UIViewController,
         }
     }
 
+    // While in the cooldown after being force muted by a moderator, we don't allow to unmute again
+    private var isInForceMuteCooldown: Bool {
+        return self.forceMutedUntil > Date()
+    }
+
+    private func presentForceMutedNotification() {
+        let micDisabledString = NSLocalizedString("Microphone disabled", comment: "")
+        let forceMutedString = NSLocalizedString("You have been muted by a moderator", comment: "")
+
+        DispatchQueue.main.async {
+            NotificationPresenter.shared().present(title: micDisabledString, subtitle: forceMutedString, includedStyle: .dark)
+            NotificationPresenter.shared().dismiss(afterDelay: self.forceMuteCooldown)
+        }
+    }
+
+    private func presentUnmuteNotPossibleYetNotification() {
+        let forceMutedString = NSLocalizedString("Muted by a moderator", comment: "")
+        let cooldownString = NSLocalizedString("You can unmute again in a few seconds", comment: "")
+
+        DispatchQueue.main.async {
+            NotificationPresenter.shared().present(title: forceMutedString, subtitle: cooldownString, includedStyle: .dark)
+            NotificationPresenter.shared().dismiss(afterDelay: self.forceMuteCooldown)
+        }
+    }
+
     func forceMuteAudio() {
         guard let callController else { return }
+
+        // Stay muted for a short time, so a force mute is not immediately undone again. This can happen
+        // when the participant mutes themselves at the same time, because toggling the mute button is
+        // based on the audio state at the time the button was pressed, which might be outdated by then.
+        self.forceMutedUntil = Date().addingTimeInterval(self.forceMuteCooldown)
 
         callController.getAudioEnabledState { isEnabled in
             // When we are already muted, no need to mute again
@@ -2174,18 +2215,35 @@ class CallViewController: UIViewController,
 
             self.setAudioMuted(true)
 
-            let micDisabledString = NSLocalizedString("Microphone disabled", comment: "")
-            let forceMutedString = NSLocalizedString("You have been muted by a moderator", comment: "")
-
-            DispatchQueue.main.async {
-                NotificationPresenter.shared().present(title: micDisabledString, subtitle: forceMutedString, includedStyle: .dark)
-                NotificationPresenter.shared().dismiss(afterDelay: 7.0)
+            if CallKitManager.isCallKitAvailable() {
+                // setAudioMuted() only reports back to CallKit when it refuses an unmute, so the
+                // CallKit UI needs to be muted here as well to stay in sync with the audio state
+                DispatchQueue.main.async {
+                    CallKitManager.sharedInstance().changeAudioMuted(true, forCall: self.room.token)
+                }
             }
+
+            self.presentForceMutedNotification()
         }
     }
 
     func setAudioMuted(_ muted: Bool) {
         guard let callController else { return }
+
+        // Ignore any attempt to unmute while being force muted by a moderator
+        if !muted, self.isInForceMuteCooldown {
+            self.presentUnmuteNotPossibleYetNotification()
+            self.setAudioMuteButtonActive(false)
+
+            if CallKitManager.isCallKitAvailable() {
+                // The unmute might have been triggered by CallKit itself, so make sure its UI is muted again
+                DispatchQueue.main.async {
+                    CallKitManager.sharedInstance().changeAudioMuted(true, forCall: self.room.token)
+                }
+            }
+
+            return
+        }
 
         callController.enableAudio(!muted)
         self.setAudioMuteButtonActive(!muted)

--- a/NextcloudTalk/Calls/CallViewController.swift
+++ b/NextcloudTalk/Calls/CallViewController.swift
@@ -130,7 +130,11 @@ class CallViewController: UIViewController,
     private var proximityTimer: Timer?
     private var isAudioOnly = false
     private var isDetailedViewVisible = false
-    private var userDisabledVideo = false
+    private var userDisabledVideo = false {
+        // The call controller recreates the local video track in this state, so the video stays
+        // disabled when the local media is recreated, e.g. when reconnecting to the call
+        didSet { self.callController?.disableVideoAtStart = self.userDisabledVideo }
+    }
     private var userDisabledSpeaker = false
     private var videoCallUpgrade = false
     private var hangingUp = false
@@ -528,6 +532,19 @@ class CallViewController: UIViewController,
     }
 
     // MARK: - Proximity sensor
+
+    // The local video is temporarily disabled while the device is held to the ear and, on devices
+    // without multitasking camera access, while the app is in the background. In contrast to
+    // userDisabledVideo this is not a user decision, so it must not be remembered for a reconnect.
+    private var isLocalVideoSuspended: Bool {
+        guard let callController else { return false }
+
+        if self.proximityState {
+            return true
+        }
+
+        return UIApplication.shared.applicationState != .active && !callController.isCameraUsableWhileInBackground()
+    }
 
     func sensorStateChange(notification: NSNotification) {
         DispatchQueue.main.async {
@@ -1142,14 +1159,16 @@ class CallViewController: UIViewController,
             return
         }
 
-        self.setVideoDisableButtonActive(videoTrack.isEnabled)
-
-        // We set _userDisabledVideo = YES so the proximity sensor doesn't enable it.
-        if !videoTrack.isEnabled {
-            self.userDisabledVideo = true
-        }
+        let isVideoEnabled = videoTrack.isEnabled
+        self.setVideoDisableButtonActive(isVideoEnabled)
 
         DispatchQueue.main.async {
+            // The track is created in the state the user selected, so a suspension that is still
+            // active (proximity sensor or app in the background) needs to be applied to it again
+            if isVideoEnabled, self.isLocalVideoSuspended {
+                self.disableLocalVideo()
+            }
+
             // The local video track might have been recreated while in Picture in Picture
             // (e.g. when reconnecting a call), so the renderer needs to be attached to the new track
             if self.pipLocalRendererAttached {

--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -51,8 +51,10 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
     private var isAudioOnly: Bool
 
     // TODO: Default true?
-    // Kept in sync by enableAudio(), so the local audio state is restored whenever the
-    // local media is recreated, e.g. when reconnecting to a call
+    // The state the local media is (re)created in, so audio and video are restored whenever the
+    // local tracks are recreated, e.g. when reconnecting to a call. The audio state is kept in
+    // sync by enableAudio(), the video state is owned by the delegate, because disabling the
+    // video temporarily (proximity sensor, app in the background) must not be remembered here.
     public var disableAudioAtStart: Bool = false
     public var disableVideoAtStart: Bool = false
     public var silentCall: Bool = false
@@ -354,10 +356,6 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
             self.userInCall = 0
             self.cleanCurrentPeerConnections()
             self.delegate?.callControllerIsReconnectingCall(self)
-
-            // Remember current video status before rejoin the call.
-            // The audio status is already kept up to date by enableAudio().
-            self.disableVideoAtStart = !self.isVideoEnabled()
 
             if self.externalSignalingController == nil {
                 self.rejoinCallUsingInternalSignaling()

--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -51,6 +51,8 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
     private var isAudioOnly: Bool
 
     // TODO: Default true?
+    // Kept in sync by enableAudio(), so the local audio state is restored whenever the
+    // local media is recreated, e.g. when reconnecting to a call
     public var disableAudioAtStart: Bool = false
     public var disableVideoAtStart: Bool = false
     public var silentCall: Bool = false
@@ -353,8 +355,8 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
             self.cleanCurrentPeerConnections()
             self.delegate?.callControllerIsReconnectingCall(self)
 
-            // Remember current audio and video status before rejoin the call
-            self.disableAudioAtStart = !self.isAudioEnabled()
+            // Remember current video status before rejoin the call.
+            // The audio status is already kept up to date by enableAudio().
             self.disableVideoAtStart = !self.isVideoEnabled()
 
             if self.externalSignalingController == nil {
@@ -625,6 +627,10 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
 
     public func enableAudio(_ enable: Bool) {
         WebRTCCommon.shared.dispatch {
+            // Remember the audio state, so it's restored when the local media is recreated.
+            // Otherwise a reconnect would unmute a muted (or force muted) participant again.
+            self.disableAudioAtStart = !enable
+
             self.localAudioTrack?.isEnabled = enable
             self.sendMessageToAll(ofType: enable ? "audioOn" : "audioOff", withPayload: nil)
 

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -1668,6 +1668,9 @@
 "Mute others" = "Mute others";
 
 /* No comment provided by engineer. */
+"Muted by a moderator" = "Muted by a moderator";
+
+/* No comment provided by engineer. */
 "My location" = "My location";
 
 /* No comment provided by engineer. */
@@ -2725,6 +2728,9 @@
 
 /* No comment provided by engineer. */
 "You can set your phone number so other users will be able to find you" = "You can set your phone number so other users will be able to find you";
+
+/* No comment provided by engineer. */
+"You can unmute again in a few seconds" = "You can unmute again in a few seconds";
 
 /* No comment provided by engineer. */
 "You cleared the history of the conversation" = "You cleared the history of the conversation";

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -2727,10 +2727,10 @@
 "You are not part of any conversation. Press + to start a new one." = "You are not part of any conversation. Press + to start a new one.";
 
 /* No comment provided by engineer. */
-"You can set your phone number so other users will be able to find you" = "You can set your phone number so other users will be able to find you";
+"You can enable your microphone again in a few seconds" = "You can enable your microphone again in a few seconds";
 
 /* No comment provided by engineer. */
-"You can unmute again in a few seconds" = "You can unmute again in a few seconds";
+"You can set your phone number so other users will be able to find you" = "You can set your phone number so other users will be able to find you";
 
 /* No comment provided by engineer. */
 "You cleared the history of the conversation" = "You cleared the history of the conversation";


### PR DESCRIPTION
Easier to check the commits individually.

* Fix1: Currently we only save the mute state when a forceReconnect is happening, so initiated by the app. What we fail to do is to save that state in other places e.g. reconnect from server, force mute by a moderator, etc. So you might end up unmuted again in the call
* Fix2: When a moderator force mutes the user which in that second tries to mute as well, the user might end up unmuted again, as the force mute overlapped the mute. We now add a cooldown phase so a user can only unmute again after a few seconds, when it was force-muted.
* Fix3: Keep the CallKit state in sync to properly indicate mute/unmute.
* Fix4: Also remember the video state across all reconnect paths.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
