### PR TITLE
fix: Displaying context menu at the wrong location

### DIFF
--- a/NextcloudTalk/Rooms/RoomTableViewCell.swift
+++ b/NextcloudTalk/Rooms/RoomTableViewCell.swift
@@ -52,6 +52,7 @@ import Foundation
         self.accessibilityIdentifier = nil
 
         self.unreadMessagesView.setBadgeNumber(0)
+        self.containerView.backgroundColor = .clear
     }
 
     public override func setSelected(_ selected: Bool, animated: Bool) {
@@ -60,6 +61,9 @@ import Foundation
         if !selected, NCUserInterfaceController.sharedInstance().roomsTableViewController.selectedRoomToken == self.roomToken {
             return
         }
+
+        // Without this, isSelected always reports false: its setter calls into this method
+        super.setSelected(selected, animated: animated)
 
         if selected {
             self.containerView.backgroundColor = NCAppBranding.elementColorBackground()

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -1803,9 +1803,13 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         let cell = tableView.dequeueReusableCell(withIdentifier: RoomTableViewCell.identifier) as? RoomTableViewCell ?? RoomTableViewCell(style: .default, reuseIdentifier: RoomTableViewCell.identifier)
 
-        cell.backgroundColor = .clear
+        configure(cell, for: rooms[indexPath.row])
 
-        let room = rooms[indexPath.row]
+        return cell
+    }
+
+    private func configure(_ cell: RoomTableViewCell, for room: NCRoom) {
+        cell.backgroundColor = .clear
 
         // Set room name
         cell.titleLabel.text = room.displayName
@@ -1848,10 +1852,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         }
 
         cell.roomToken = room.token
-
-        return cell
     }
-
     override func tableView(_ tableView: UITableView, didHighlightRowAt indexPath: IndexPath) {
         let cell = tableView.cellForRow(at: indexPath) as? RoomTableViewCell
         cell?.isSelected = true
@@ -2168,6 +2169,38 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         return configuration
     }
 
+    /// Uses a cell from the nib, not the reuse pool: a label that was displayed already does not render
+    /// into a bitmap on iPad in split view, and handing over the live cell means UIKit reparents it
+    private func contextMenuPreview(for indexPath: IndexPath, alpha: CGFloat) -> UITargetedPreview? {
+        guard let room = room(for: indexPath),
+              let previewCell = UINib(nibName: RoomTableViewCell.nibName, bundle: nil).instantiate(withOwner: nil).first as? RoomTableViewCell
+        else { return nil }
+
+        let rowRect = self.tableView.rectForRow(at: indexPath)
+
+        previewCell.frame = CGRect(origin: .zero, size: rowRect.size)
+        configure(previewCell, for: room)
+
+        // Only set for cells the table view displays, so the preview has to do it itself
+        previewCell.avatarView.setStatus(for: room, allowCustomStatusIcon: true)
+
+        // The row takes its background from the table view, the floating card needs its own
+        previewCell.containerView.backgroundColor = .systemBackground
+        previewCell.contentView.alpha = alpha
+        previewCell.layoutIfNeeded()
+
+        let parameters = UIPreviewParameters()
+
+        // The card brings its own background, UIKit filling one in would stay behind a transparent preview
+        parameters.backgroundColor = .clear
+        parameters.visiblePath = UIBezierPath(roundedRect: previewCell.containerView.frame, cornerRadius: previewCell.containerView.layer.cornerRadius)
+
+        // Our view is the table view, so the row rect is already in the coordinate space of the container
+        let target = UIPreviewTarget(container: self.view, center: CGPoint(x: rowRect.midX, y: rowRect.midY))
+
+        return UITargetedPreview(view: previewCell.contentView, parameters: parameters, target: target)
+    }
+
     override func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
         if tableView != self.tableView {
             return nil
@@ -2175,35 +2208,18 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
 
-        // A cell from the dataSource is detached and never rendered, it would still show the content and position of its previous row
-        guard let cell = self.tableView.cellForRow(at: indexPath) as? RoomTableViewCell else { return nil }
+        return contextMenuPreview(for: indexPath, alpha: 1)
+    }
 
-        // Keep the selection background of the long press out of the floating preview
-        let previousContainerBackground = cell.containerView.backgroundColor
-        cell.containerView.backgroundColor = .clear
+    override func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
+        if tableView != self.tableView {
+            return nil
+        }
 
-        let snapshot = cell.contentView.snapshotView(afterScreenUpdates: true)
+        guard let indexPath = configuration.identifier as? IndexPath else { return nil }
 
-        cell.containerView.backgroundColor = previousContainerBackground
-
-        guard let previewView = snapshot else { return nil }
-        previewView.backgroundColor = .systemBackground
-
-        let rowRect = self.tableView.rectForRow(at: indexPath)
-
-        // On large iPhones (with regular landscape size, like iPhone X) we need to take the safe area into account when calculating the center
-        let cellCenterX = rowRect.midX + self.view.safeAreaInsets.left / 2 - self.view.safeAreaInsets.right / 2
-        let cellCenter = CGPoint(x: cellCenterX, y: rowRect.midY)
-
-        // Create a preview target which allows us to have a transparent background
-        let previewTarget = UIPreviewTarget(container: self.view, center: cellCenter)
-        let previewParameter = UIPreviewParameters()
-
-        // Remove the background and the drop shadow from our custom preview view
-        previewParameter.backgroundColor = .systemBackground
-        previewParameter.shadowPath = UIBezierPath()
-
-        return UITargetedPreview(view: previewView, parameters: previewParameter, target: previewTarget)
+        // Describes the state the menu animates back to, so a transparent card fades the whole preview out
+        return contextMenuPreview(for: indexPath, alpha: 0)
     }
 
     override func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -2176,16 +2176,15 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
 
         // A cell from the dataSource is detached and never rendered, it would still show the content and position of its previous row
-        guard let cell = self.tableView.cellForRow(at: indexPath) else { return nil }
+        guard let cell = self.tableView.cellForRow(at: indexPath) as? RoomTableViewCell else { return nil }
 
         // Keep the selection background of the long press out of the floating preview
-        let roomCell = cell as? RoomTableViewCell
-        let previousContainerBackground = roomCell?.containerView.backgroundColor
-        roomCell?.containerView.backgroundColor = .clear
+        let previousContainerBackground = cell.containerView.backgroundColor
+        cell.containerView.backgroundColor = .clear
 
-        let snapshot = cell.contentView.snapshotView(afterScreenUpdates: roomCell != nil)
+        let snapshot = cell.contentView.snapshotView(afterScreenUpdates: true)
 
-        roomCell?.containerView.backgroundColor = previousContainerBackground
+        cell.containerView.backgroundColor = previousContainerBackground
 
         guard let previewView = snapshot else { return nil }
         previewView.backgroundColor = .systemBackground

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -57,10 +57,17 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
     private var contextMenuActionBlock: (() -> Void)?
 
-    // While a context menu is being displayed we defer room list reloads, otherwise reloading the
-    // table moves the cells out from under the floating context menu preview, making it overlay
-    // unrelated cells. Any refresh that arrives meanwhile is coalesced and applied once the menu ends.
-    private var isContextMenuActive = false
+    /// A single context menu interaction, from the long press until the menu was dismissed or the press was cancelled
+    private class ContextMenuInteraction {
+        let configuration: UIContextMenuConfiguration
+        var isMenuDisplayed = false
+
+        init(configuration: UIContextMenuConfiguration) {
+            self.configuration = configuration
+        }
+    }
+
+    private var activeContextMenuInteraction: ContextMenuInteraction?
     private var pendingRoomListRefresh = false
 
     override func viewDidLoad() {
@@ -312,7 +319,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         // Reset deferred-refresh state in case the context menu was dismissed by navigating away
         // without a willEndContextMenuInteraction callback, so refreshes aren't skipped indefinitely.
-        isContextMenuActive = false
+        activeContextMenuInteraction = nil
         pendingRoomListRefresh = false
     }
 
@@ -1130,7 +1137,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
     @objc func refreshRoomList() {
         // Don't reload while a context menu is open, as that would detach the preview from its cell.
         // The refresh is applied once the context menu interaction ends.
-        if isContextMenuActive {
+        if activeContextMenuInteraction != nil {
             pendingRoomListRefresh = true
             return
         }
@@ -1910,6 +1917,23 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         presentChatForRoom(at: indexPath)
     }
 
+    /// An interaction cancelled before the menu is displayed never reports back, don't defer refreshes forever
+    private func startContextMenuGuardWatchdog(for interaction: ContextMenuInteraction) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self, weak interaction] in
+            guard let self, let interaction,
+                  self.activeContextMenuInteraction === interaction,
+                  !interaction.isMenuDisplayed
+            else { return }
+
+            self.activeContextMenuInteraction = nil
+
+            if self.pendingRoomListRefresh {
+                self.pendingRoomListRefresh = false
+                self.refreshRoomList()
+            }
+        }
+    }
+
     // swiftlint:disable:next cyclomatic_complexity
     override func tableView(_ tableView: UITableView, contextMenuConfigurationForRowAt indexPath: IndexPath, point: CGPoint) -> UIContextMenuConfiguration? {
         if tableView != self.tableView ||
@@ -2136,6 +2160,11 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
             return menu
         })
 
+        // Defer refreshes from here on: UIKit already determined which cell to lift, although the menu is only displayed a moment later
+        let interaction = ContextMenuInteraction(configuration: configuration)
+        activeContextMenuInteraction = interaction
+        startContextMenuGuardWatchdog(for: interaction)
+
         return configuration
     }
 
@@ -2146,14 +2175,26 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         guard let indexPath = configuration.identifier as? IndexPath else { return nil }
 
-        // Use a snapshot and a new cell (from dataSource) here to not interfere with room refresh
-        guard let cell = self.tableView.dataSource?.tableView(self.tableView, cellForRowAt: indexPath) else { return nil }
-        guard let previewView = cell.contentView.snapshotView(afterScreenUpdates: false) else { return nil }
+        // A cell from the dataSource is detached and never rendered, it would still show the content and position of its previous row
+        guard let cell = self.tableView.cellForRow(at: indexPath) else { return nil }
+
+        // Keep the selection background of the long press out of the floating preview
+        let roomCell = cell as? RoomTableViewCell
+        let previousContainerBackground = roomCell?.containerView.backgroundColor
+        roomCell?.containerView.backgroundColor = .clear
+
+        let snapshot = cell.contentView.snapshotView(afterScreenUpdates: roomCell != nil)
+
+        roomCell?.containerView.backgroundColor = previousContainerBackground
+
+        guard let previewView = snapshot else { return nil }
         previewView.backgroundColor = .systemBackground
 
+        let rowRect = self.tableView.rectForRow(at: indexPath)
+
         // On large iPhones (with regular landscape size, like iPhone X) we need to take the safe area into account when calculating the center
-        let cellCenterX = cell.center.x + self.view.safeAreaInsets.left / 2 - self.view.safeAreaInsets.right / 2
-        let cellCenter = CGPoint(x: cellCenterX, y: cell.center.y)
+        let cellCenterX = rowRect.midX + self.view.safeAreaInsets.left / 2 - self.view.safeAreaInsets.right / 2
+        let cellCenter = CGPoint(x: cellCenterX, y: rowRect.midY)
 
         // Create a preview target which allows us to have a transparent background
         let previewTarget = UIPreviewTarget(container: self.view, center: cellCenter)
@@ -2171,7 +2212,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
             return
         }
 
-        isContextMenuActive = true
+        activeContextMenuInteraction?.isMenuDisplayed = true
     }
 
     override func tableView(_ tableView: UITableView, willEndContextMenuInteraction configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
@@ -2180,7 +2221,10 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         }
 
         animator?.addCompletion {
-            self.isContextMenuActive = false
+            // Don't touch the state if a new long press started while this menu was animating away
+            if self.activeContextMenuInteraction?.configuration === configuration {
+                self.activeContextMenuInteraction = nil
+            }
 
             // Wait until the context menu is completely hidden before we execute any method
             if let contextMenuActionBlock = self.contextMenuActionBlock {


### PR DESCRIPTION
When long-pressing at the wrong time, we will display the context-menu/preview-cell at the wrong location and even with the wrong content. That makes it problematic to execute the actions on the correct cells.

There were multiple issues:
* The context menu active guard was not complete, a reload could happen between building the context menu and showing it
* The preview cell we dequeued was never rendered/reused, so it would show the old content
* Similar to the previous issue, the cell would be displayed at the wrong location
* The background color we use for highlighting the cell was never correctly reset, which sometimes showed the selected background on the preview cell

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
