### PR TITLE
fix: Render markdown and links in the room description again

### DIFF
--- a/NextcloudTalk/Chat/Chat views/MessageBodyTextView.swift
+++ b/NextcloudTalk/Chat/Chat views/MessageBodyTextView.swift
@@ -4,7 +4,38 @@
 //
 
 import UIKit
+import SwiftUI
 import CDMarkdownKit
+
+struct MessageBodyTextViewWrapper: UIViewRepresentable {
+    let attributedText: NSAttributedString
+
+    func makeUIView(context: Context) -> MessageBodyTextView {
+        let textView = MessageBodyTextView()
+
+        // The intrinsic width of a non-scrolling text view is the whole text on a single line, don't let that drive the layout
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        return textView
+    }
+
+    func updateUIView(_ textView: MessageBodyTextView, context: Context) {
+        textView.attributedText = attributedText
+    }
+
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView textView: MessageBodyTextView, context: Context) -> CGSize? {
+        // Without a concrete width there's nothing to wrap the text at, fall back to the intrinsic size
+        guard let width = proposal.width, width > 0, width < .greatestFiniteMagnitude else { return nil }
+
+        // Since textContainerInset and lineFragmentPadding are zero, the used rect is the full height we need
+        textView.textContainer.size = CGSize(width: width, height: .greatestFiniteMagnitude)
+        textView.layoutManager.ensureLayout(for: textView.textContainer)
+
+        let usedRect = textView.layoutManager.usedRect(for: textView.textContainer)
+
+        return CGSize(width: width, height: ceil(usedRect.height))
+    }
+}
 
 class MessageBodyTextView: UITextView, UITextViewDelegate {
 

--- a/NextcloudTalk/Chat/Chat views/MessageTextViewController.xib
+++ b/NextcloudTalk/Chat/Chat views/MessageTextViewController.xib
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24127" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24765" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24063"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24743"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="GithubPermalinkViewController" customModule="NextcloudTalk" customModuleProvider="target">
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="MessageTextViewController" customModule="NextcloudTalk" customModuleProvider="target">
             <connections>
                 <outlet property="messageTextView" destination="cBP-KD-G41" id="i1n-9c-Aw9"/>
                 <outlet property="view" destination="i5M-Pr-FkT" id="sfx-zR-JGt"/>
@@ -22,7 +22,7 @@
             <subviews>
                 <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" layoutManager="textKit1" translatesAutoresizingMaskIntoConstraints="NO" id="cBP-KD-G41" userLabel="MessageTextView">
                     <rect key="frame" x="10" y="160" width="394" height="658"/>
-                    <color key="backgroundColor" systemColor="secondarySystemGroupedBackgroundColor"/>
+                    <color key="backgroundColor" systemColor="secondarySystemBackgroundColor"/>
                     <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                     <color key="textColor" systemColor="labelColor"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
@@ -45,8 +45,8 @@
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
-        <systemColor name="secondarySystemGroupedBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        <systemColor name="secondarySystemBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/NextcloudTalk/Rooms/NCRoom.swift
+++ b/NextcloudTalk/Rooms/NCRoom.swift
@@ -379,7 +379,7 @@ extension Array where Element == NCRoom {
     }
 
     @nonobjc
-    public var parsedRoomDescription: AttributedString? {
+    public var parsedRoomDescription: NSAttributedString? {
         guard
             NCDatabaseManager.sharedInstance().serverHasTalkCapability(.roomDescription, forAccountId: accountId),
             let description = self.roomDescription,
@@ -388,7 +388,7 @@ extension Array where Element == NCRoom {
 
         let attributedDescription = description.withFont(.preferredFont(forTextStyle: .body)).withTextColor(.label)
 
-        return AttributedString(SwiftMarkdownObjCBridge.parseMarkdown(markdownString: attributedDescription))
+        return SwiftMarkdownObjCBridge.parseMarkdown(markdownString: attributedDescription)
     }
 
     // TODO: Move to lazy

--- a/NextcloudTalk/Rooms/RoomInfo/RoomInfoHeaderSection.swift
+++ b/NextcloudTalk/Rooms/RoomInfo/RoomInfoHeaderSection.swift
@@ -27,9 +27,23 @@ struct RoomInfoHeaderSection: View {
 
         if let description = room.parsedRoomDescription {
             Section {
-                // TODO: Use UITextView wrapper to enable data detectors
-                Text(description)
-                    .textSelection(.enabled)
+                MessageBodyTextViewWrapper(attributedText: description)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .contextMenu {
+                        Button {
+                            UIPasteboard.general.string = room.roomDescription
+                            NotificationPresenter.shared().present(text: NSLocalizedString("Description copied", comment: "The description text of a conversation was copied to the clipboard"), dismissAfterDelay: 5.0, includedStyle: .dark)
+                        } label: {
+                            Label(NSLocalizedString("Copy", comment: ""), systemImage: "doc.on.doc")
+                        }
+
+                        Button {
+                            let textViewController = MessageTextViewController(messageText: room.roomDescription ?? "")
+                            hostingWrapper.presentViewController(NCNavigationController(rootViewController: textViewController), animated: true)
+                        } label: {
+                            Label(NSLocalizedString("Copy selection", comment: "Copy a 'selection' of the description text of a conversation"), systemImage: "text.viewfinder")
+                        }
+                    }
             }
         }
 

--- a/NextcloudTalk/en.lproj/Localizable.strings
+++ b/NextcloudTalk/en.lproj/Localizable.strings
@@ -742,6 +742,9 @@
 /* No comment provided by engineer. */
 "Copy message selection" = "Copy message selection";
 
+/* Copy a 'selection' of the description text of a conversation */
+"Copy selection" = "Copy selection";
+
 /* No comment provided by engineer. */
 "Could not access camera" = "Could not access camera";
 
@@ -954,6 +957,9 @@
 
 /* No comment provided by engineer. */
 "Description cannot be longer than 500 characters" = "Description cannot be longer than 500 characters";
+
+/* The description text of a conversation was copied to the clipboard */
+"Description copied" = "Description copied";
 
 /* No comment provided by engineer. */
 "Details" = "Details";


### PR DESCRIPTION
SwiftUIs `Text` does not render links by default. Also we don't render markdown there. Since we already have a `MessageBodyTextView` we can re-use that and full link/markdown support again.
Additionally added a context menu which allows copying.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
