### PR TITLE
fix: Keep filter chips inside the safe area

### DIFF
--- a/NextcloudTalk/Rooms/RoomTagsFilterView.swift
+++ b/NextcloudTalk/Rooms/RoomTagsFilterView.swift
@@ -70,8 +70,8 @@ class RoomTagsFilterView: UIView {
         scrollView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: self.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: self.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
             scrollView.topAnchor.constraint(equalTo: self.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
 


### PR DESCRIPTION
Fix #2649 


## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
