### PR TITLE
chore: Use non-global traitCollections

### DIFF
--- a/NextcloudTalk/AppDelegate.swift
+++ b/NextcloudTalk/AppDelegate.swift
@@ -221,6 +221,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate, PKPushRegistryDelegate {
         return false
     }
 
+    // TODO: Modernization - Consider adopting `prefersInterfaceOrientationLocked` (iOS 26+) as the modern replacement
+    // for locking orientation through `supportedInterfaceOrientationsFor`. The view controller that wants the lock
+    // (BaseChatViewController, while recording a voice message) would override `prefersInterfaceOrientationLocked` and
+    // call `setNeedsUpdateOfPrefersInterfaceOrientationLocked()` when it flips, instead of reaching into AppDelegate to
+    // set `shouldLockInterfaceOrientation`. That also removes the `UIApplication.shared.statusBarOrientation` read in
+    // this file's `shouldLockInterfaceOrientation` observer, which is itself deprecated and app-wide rather than
+    // per-scene. Note the lock is orientation-specific (landscapeLeft vs landscapeRight are distinguished here), so it
+    // cannot be expressed as a size-class or bounds comparison.
     func application(_ application: UIApplication, supportedInterfaceOrientationsFor window: UIWindow?) -> UIInterfaceOrientationMask {
         if shouldLockInterfaceOrientation {
             if lockedInterfaceOrientation == .portrait {

--- a/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell+Location.swift
+++ b/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell+Location.swift
@@ -47,6 +47,15 @@ extension BaseChatTableViewCell {
                 messageTextView.topAnchor.constraint(equalTo: locationPreviewImageView.bottomAnchor, constant: 10),
                 messageTextView.bottomAnchor.constraint(equalTo: self.messageBodyView.bottomAnchor)
             ])
+
+            // The map snapshot is rendered at the display scale, so it has to be retaken when that changes
+            if #available(iOS 17.0, *) {
+                registerForTraitChanges([UITraitDisplayScale.self]) { (self: BaseChatTableViewCell, _) in
+                    guard let message = self.message else { return }
+
+                    self.setupForLocationCell(with: message)
+                }
+            }
         }
 
         guard let locationPreviewImageView = self.locationPreviewImageView,
@@ -68,7 +77,7 @@ extension BaseChatTableViewCell {
         let options: MKMapSnapshotter.Options = .init()
         options.region = mapRegion
         options.size = mapView.frame.size
-        options.scale = UIScreen.main.scale
+        options.scale = self.traitCollection.displayScale
 
         let locationMapSnapshooter = MKMapSnapshotter(options: options)
         self.locationMapSnapshooter = locationMapSnapshooter

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -454,7 +454,7 @@ import SwiftUI
 
                     action.subtitle = message.lastMessagePreview()?.string
                     if let image = AvatarManager.shared.getThreadAvatar(for: thread, with: self.traitCollection.userInterfaceStyle) {
-                        action.image = NCUtils.roundedImage(fromImage: image)
+                        action.image = NCUtils.roundedImage(fromImage: image, traitCollection: self.traitCollection)
                     }
 
                     menuCreationGroup.leave()

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -563,7 +563,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
                 var accountImage = NCAPIController.sharedInstance().userProfileImage(forAccount: account, withStyle: self.traitCollection.userInterfaceStyle)
 
                 if var image = accountImage {
-                    image = NCUtils.roundedImage(fromImage: image)
+                    image = NCUtils.roundedImage(fromImage: image, traitCollection: self.traitCollection)
 
                     // Draw a red circle to the image in case we have unread notifications for that account
                     if account.unreadNotification {
@@ -600,7 +600,7 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
                 let activeAccount = NCDatabaseManager.sharedInstance().activeAccount()
                 var accountImage = NCAPIController.sharedInstance().userProfileImage(forAccount: activeAccount, withStyle: self.traitCollection.userInterfaceStyle)
                 if let image = accountImage {
-                    accountImage = NCUtils.roundedImage(fromImage: image)
+                    accountImage = NCUtils.roundedImage(fromImage: image, traitCollection: self.traitCollection)
                 }
                 let activeAccountAction = UIAction(title: activeAccount.userDisplayName, image: accountImage, identifier: nil) { _ in }
                 activeAccountAction.subtitle = activeAccount.server.replacingOccurrences(of: "https://", with: "")

--- a/NextcloudTalk/Settings/NCSettingsController.swift
+++ b/NextcloudTalk/Settings/NCSettingsController.swift
@@ -146,6 +146,13 @@ public class NCSettingsController: NSObject {
         for account in NCDatabaseManager.sharedInstance().allAccounts() {
             var accountImage = NCAPIController.sharedInstance().userProfileImage(forAccount: account, withStyle: .light)
             if let image = accountImage {
+                // TODO: Modernization - This uses the deprecated NCUtils.roundedImage(fromImage:), which renders at
+                // UITraitCollection.current.displayScale. The correct call is roundedImage(fromImage:traitCollection:),
+                // but the trait collection cannot be threaded here: createAccountsFile() is invoked from a background
+                // queue in AppDelegate and from account add/remove flows, none of which have a view in scope, and the
+                // resulting image is written to the shared app group for *other* Nextcloud apps to read - so there is no
+                // single display it belongs to. Pick a fixed scale for the on-disk representation instead of a
+                // display-derived one, or pass the trait collection down from whichever UI triggers the write.
                 accountImage = NCUtils.roundedImage(fromImage: image)
             }
             let accountData = NKShareAccounts.DataAccounts(withUrl: account.server, user: account.user, name: account.userDisplayName, image: accountImage)

--- a/NextcloudTalk/Settings/NCUtils.swift
+++ b/NextcloudTalk/Settings/NCUtils.swift
@@ -342,11 +342,16 @@ import AVFoundation
         return nil
     }
 
+    @available(*, deprecated, message: "use roundedImage(fromImage:traitCollection:) instead")
     public static func roundedImage(fromImage image: UIImage) -> UIImage {
+        return roundedImage(fromImage: image, traitCollection: .current)
+    }
+
+    public static func roundedImage(fromImage image: UIImage, traitCollection: UITraitCollection) -> UIImage {
         let imageSize = image.size
         let rect = CGRect(x: 0, y: 0, width: imageSize.width, height: imageSize.width)
 
-        UIGraphicsBeginImageContextWithOptions(imageSize, false, UIScreen.main.scale)
+        UIGraphicsBeginImageContextWithOptions(imageSize, false, traitCollection.displayScale)
         UIBezierPath(roundedRect: rect, cornerRadius: imageSize.height).addClip()
         image.draw(in: rect)
 
@@ -383,7 +388,12 @@ import AVFoundation
         return newImage
     }
 
+    @available(*, deprecated, message: "use getImage(withString:withBackgroundColor:withBounds:isCircular:traitCollection:) instead")
     public static func getImage(withString string: String, withBackgroundColor color: UIColor, withBounds bounds: CGRect, isCircular circular: Bool) -> UIImage? {
+        return getImage(withString: string, withBackgroundColor: color, withBounds: bounds, isCircular: circular, traitCollection: .current)
+    }
+
+    public static func getImage(withString string: String, withBackgroundColor color: UIColor, withBounds bounds: CGRect, isCircular circular: Bool, traitCollection: UITraitCollection) -> UIImage? {
         // Based on the "UIImageView+Letters" library from Tom Bachant
 
         let fontSize = bounds.width * 0.5
@@ -396,7 +406,7 @@ import AVFoundation
             displayString.append(firstCharacter)
         }
 
-        let scale = Float(UIScreen.main.scale)
+        let scale = Float(traitCollection.displayScale)
         let width = floorf(Float(bounds.size.width) * scale) / scale
         let height = floorf(Float(bounds.size.height) * scale) / scale
         let size = CGSize(width: CGFloat(width), height: CGFloat(height))

--- a/NextcloudTalk/Settings/SettingsTableViewController.swift
+++ b/NextcloudTalk/Settings/SettingsTableViewController.swift
@@ -103,6 +103,13 @@ class SettingsTableViewController: UITableViewController, UITextFieldDelegate, U
         typingIndicatorSwitch.frame = .zero
         typingIndicatorSwitch.addTarget(self, action: #selector(typingIndicatorValueChanged(_:)), for: .valueChanged)
 
+        // Account images are rendered at the display scale, so they have to be regenerated when it changes
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitDisplayScale.self]) { (self: SettingsTableViewController, _) in
+                self.tableView.reloadData()
+            }
+        }
+
         NotificationCenter.default.addObserver(self, selector: #selector(appStateHasChanged(notification:)), name: NSNotification.Name.NCAppStateHasChangedNotification, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(contactsHaveBeenUpdated(notification:)), name: NSNotification.Name.NCContactsManagerContactsUpdated, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(contactsAccessHasBeenUpdated(notification:)), name: NSNotification.Name.NCContactsManagerContactsAccessUpdated, object: nil)
@@ -871,7 +878,7 @@ extension SettingsTableViewController {
         cell.detailTextLabel?.lineBreakMode = .byCharWrapping
 
         if let accountImage = self.getProfilePicture(for: account) {
-            cell.setSettingsImage(image: NCUtils.roundedImage(fromImage: accountImage), renderingMode: .alwaysOriginal)
+            cell.setSettingsImage(image: NCUtils.roundedImage(fromImage: accountImage, traitCollection: self.traitCollection), renderingMode: .alwaysOriginal)
         }
 
         if account.unreadBadgeNumber > 0 {

--- a/NextcloudTalk/User Interface/AvatarButton.swift
+++ b/NextcloudTalk/User Interface/AvatarButton.swift
@@ -71,7 +71,7 @@ import SDWebImage
     public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount) {
         self.currentRequest?.cancel()
 
-        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, usingAccount: account, traitCollection: self.traitCollection) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/User Interface/AvatarImageView.swift
+++ b/NextcloudTalk/User Interface/AvatarImageView.swift
@@ -97,7 +97,7 @@ struct AvatarImageViewWrapper: UIViewRepresentable {
     public func setActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, using account: TalkAccount) {
         self.currentRequest?.cancel()
 
-        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, withStyle: self.traitCollection.userInterfaceStyle, usingAccount: account) { image in
+        self.currentRequest = AvatarManager.shared.getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, usingAccount: account, traitCollection: self.traitCollection) { image in
             guard let image = image else {
                 return
             }

--- a/NextcloudTalk/User Interface/AvatarManager.swift
+++ b/NextcloudTalk/User Interface/AvatarManager.swift
@@ -121,10 +121,23 @@ import SDWebImage
 
     // swiftlint:disable:next function_parameter_count
     @discardableResult
+    @available(*, deprecated, message: "use getActorAvatar(forId:withType:withDisplayName:withRoomToken:usingAccount:traitCollection:completionBlock:) instead")
     public func getActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        // The caller's style stays authoritative and is layered over the current traits, which supply the display scale
+        let traitCollection = UITraitCollection(traitsFrom: [.current, UITraitCollection(userInterfaceStyle: style)])
+
+        return getActorAvatar(forId: actorId, withType: actorType, withDisplayName: actorDisplayName, withRoomToken: roomToken, usingAccount: account, traitCollection: traitCollection, completionBlock: completionBlock)
+    }
+
+    // swiftlint:disable:next function_parameter_count
+    @discardableResult
+    public func getActorAvatar(forId actorId: String?, withType actorType: String?, withDisplayName actorDisplayName: String?, withRoomToken roomToken: String?, usingAccount account: TalkAccount, traitCollection: UITraitCollection, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+        // The avatar endpoints take the raw style, everything else takes the full trait collection
+        let style = traitCollection.userInterfaceStyle
+
         if let actorId {
             if actorType == "bots" {
-                return getBotsAvatar(forId: actorId, withStyle: style, completionBlock: completionBlock)
+                return getBotsAvatar(forId: actorId, traitCollection: traitCollection, completionBlock: completionBlock)
             } else if actorType == "users" {
                 return getUserAvatar(forId: actorId, withStyle: style, usingAccount: account, completionBlock: completionBlock)
             } else if actorType == "federated_users" {
@@ -135,44 +148,42 @@ import SDWebImage
         var image: UIImage?
 
         if actorType == AttendeeType.email.rawValue || actorType == AttendeeType.guest.rawValue {
-            image = self.getGuestsAvatar(withDisplayName: actorDisplayName ?? "", withStyle: style)
+            image = self.getGuestsAvatar(withDisplayName: actorDisplayName ?? "", traitCollection: traitCollection)
         } else if actorType == AttendeeType.group.rawValue {
             image = self.getGroupAvatar(with: style)
         } else if actorType == AttendeeType.circle.rawValue || actorType == AttendeeType.teams.rawValue {
             image = self.getTeamAvatar(with: style)
         } else if actorType == "deleted_users" {
-            image = self.getDeletedUserAvatar()
+            image = self.getDeletedUserAvatar(traitCollection: traitCollection)
         } else {
-            image = NCUtils.getImage(withString: "?", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
+            image = NCUtils.getImage(withString: "?", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true, traitCollection: traitCollection)
         }
 
         completionBlock(image)
         return nil
     }
 
-    private func getBotsAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
+    private func getBotsAvatar(forId actorId: String, traitCollection: UITraitCollection, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {
         if actorId == "changelog" || actorId == "sample" {
-            let traitCollection = UITraitCollection(userInterfaceStyle: style)
             completionBlock(UIImage(named: "changelog-avatar", in: nil, compatibleWith: traitCollection))
         } else {
-            let image = NCUtils.getImage(withString: ">", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
+            let image = NCUtils.getImage(withString: ">", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true, traitCollection: traitCollection)
             completionBlock(image)
         }
 
         return nil
     }
 
-    private func getGuestsAvatar(withDisplayName actorDisplayName: String, withStyle style: UIUserInterfaceStyle) -> UIImage? {
+    private func getGuestsAvatar(withDisplayName actorDisplayName: String, traitCollection: UITraitCollection) -> UIImage? {
         if actorDisplayName.isEmpty {
-            let traitCollection = UITraitCollection(userInterfaceStyle: style)
             return UIImage(named: "user-avatar", in: nil, compatibleWith: traitCollection)
         }
 
-        return NCUtils.getImage(withString: actorDisplayName, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
+        return NCUtils.getImage(withString: actorDisplayName, withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true, traitCollection: traitCollection)
     }
 
-    private func getDeletedUserAvatar() -> UIImage? {
-        return NCUtils.getImage(withString: "X", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true)
+    private func getDeletedUserAvatar(traitCollection: UITraitCollection) -> UIImage? {
+        return NCUtils.getImage(withString: "X", withBackgroundColor: .systemGray3, withBounds: self.avatarDefaultSize, isCircular: true, traitCollection: traitCollection)
     }
 
     private func getUserAvatar(forId actorId: String, withStyle style: UIUserInterfaceStyle, usingAccount account: TalkAccount, completionBlock: @escaping (_ image: UIImage?) -> Void) -> SDWebImageCombinedOperation? {

--- a/ShareExtension/ShareConfirmationViewController.swift
+++ b/ShareExtension/ShareConfirmationViewController.swift
@@ -326,6 +326,14 @@ import MBProgressHUD
     public override func viewDidLoad() {
         super.viewDidLoad()
 
+        // Thumbnails are generated at the display scale, so they have to be regenerated when it changes.
+        // Registered before the token guard below, which can return early.
+        if #available(iOS 17.0, *) {
+            registerForTraitChanges([UITraitDisplayScale.self]) { (self: ShareConfirmationViewController, _) in
+                self.shareCollectionView.reloadData()
+            }
+        }
+
         // Configure communication lib
         guard let userToken = NCKeyChainController.sharedInstance().token(forAccountId: self.account.accountId) else { return }
         let userAgent = "Mozilla/5.0 (iOS) Nextcloud-Talk v\(Bundle.main.infoDictionary?["CFBundleShortVersionString"] ?? "Unknown")"
@@ -813,7 +821,7 @@ import MBProgressHUD
 
     func generatePreview(for cell: ShareConfirmationCollectionViewCell, with collectionView: UICollectionView, with item: ShareItem) {
         let size = CGSize(width: collectionView.bounds.width, height: collectionView.bounds.height)
-        let scale = self.view.window?.screen.scale ?? UIScreen.main.scale
+        let scale = self.traitCollection.displayScale
 
         // updateHandler might be called multiple times, starting from low quality representation to high-quality
         let request = QLThumbnailGenerator.Request(fileAt: item.fileURL, size: size, scale: scale, representationTypes: [.lowQualityThumbnail, .thumbnail])

--- a/TalkIntents/AccountEntity.swift
+++ b/TalkIntents/AccountEntity.swift
@@ -21,6 +21,12 @@ struct AccountEntity: AppEntity {
         server = account.server.replacingOccurrences(of: "https://", with: "")
 
         if let image = NCAPIController.sharedInstance().userProfileImage(forAccount: account, withStyle: .light) {
+            // TODO: Modernization - This uses the deprecated NCUtils.roundedImage(fromImage:), which renders at
+            // UITraitCollection.current.displayScale. The correct call is roundedImage(fromImage:traitCollection:),
+            // but there is nothing to pass: AccountEntity is built by AccountEntityQuery (an EntityQuery protocol
+            // requirement whose signature cannot take a trait collection) and is rendered out-of-process by Siri and
+            // Shortcuts, so no window or display context exists here. Render the entity image at a fixed scale
+            // appropriate for DisplayRepresentation instead of a display-derived one.
             let roundedImage = NCUtils.roundedImage(fromImage: image)
             imageData = roundedImage.pngData()
         }


### PR DESCRIPTION
* Ref https://github.com/nextcloud-deps/SlackTextViewController/pull/29
* Ref https://github.com/nextcloud/talk-ios/pull/2656

This is not strictly needed for the UIScene transition, but it is recommended by apple and done in the same skill, still split it in 2 PRs. We can in theory skip this PR for now, at the same time, it shouldn't cause any harm either.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
