### PR TITLE
fix: Wrap updateConversationTags transaction in a background task

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -599,9 +599,7 @@ import Toast
         temporaryMessage.isSilent = silently
         temporaryMessage.isMarkdownMessage = NCDatabaseManager.sharedInstance().roomHasTalkCapability(.markdownMessages, for: self.room)
 
-        let realm = RLMRealm.default()
-
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             realm.add(temporaryMessage)
         }
 
@@ -644,9 +642,7 @@ import Toast
     }
 
     internal func removePermanentlyTemporaryMessage(temporaryMessage: NCChatMessage) {
-        let realm = RLMRealm.default()
-
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             if let managedTemporaryMessage = NCChatMessage.objects(where: "referenceId = %@ AND isTemporary = true", temporaryMessage.referenceId).firstObject() {
                 realm.delete(managedTemporaryMessage)
             }

--- a/NextcloudTalk/Chat/NCChatController.swift
+++ b/NextcloudTalk/Chat/NCChatController.swift
@@ -250,8 +250,7 @@ public class NCChatController: NSObject {
     }
 
     private func storeMessages(_ messages: [[String: Any]]) {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             self.storeMessages(messages.map { $0 as [AnyHashable: Any] }, with: realm)
         }
     }
@@ -262,8 +261,7 @@ public class NCChatController: NSObject {
     }
 
     private func removeAllStoredMessagesAndChatBlocks() {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             let query = NSPredicate(format: "accountId = %@ AND token = %@", self.account.accountId, self.room.token)
             realm.deleteObjects(NCChatMessage.objects(with: query))
             realm.deleteObjects(NCChatBlock.objects(with: query))
@@ -273,9 +271,9 @@ public class NCChatController: NSObject {
     }
 
     public func removeExpiredMessages() {
-        let realm = RLMRealm.default()
         let currentTimestamp = Int(Date().timeIntervalSince1970)
-        try? realm.transaction {
+
+        RLMRealm.writeTransaction { realm in
             let query = NSPredicate(format: "accountId = %@ AND token = %@ AND expirationTimestamp > 0 AND expirationTimestamp <= %ld", self.account.accountId, self.room.token, currentTimestamp)
             realm.deleteObjects(NCChatMessage.objects(with: query))
         }
@@ -284,8 +282,7 @@ public class NCChatController: NSObject {
     private func updateLastChatBlock(withNewestKnown newestKnown: Int) {
         guard newestKnown > 0 else { return }
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             let managedSortedBlocks = self.managedSortedBlocksForRoomOrThread()
             if let lastBlock = managedSortedBlocks.lastObject() as? NCChatBlock, newestKnown > lastBlock.newestMessageId {
                 lastBlock.newestMessageId = newestKnown
@@ -301,8 +298,7 @@ public class NCChatController: NSObject {
         // Safety check: prevent storing a messageId older than the thread's first message as block's oldestMessageId when in a thread controller
         let oldestMessageKnown = (isThreadController && lastKnown < threadId) ? threadId : lastKnown
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             let managedSortedBlocks = self.managedSortedBlocksForRoomOrThread()
             guard let lastBlock = managedSortedBlocks.lastObject() as? NCChatBlock else { return }
 
@@ -348,8 +344,7 @@ public class NCChatController: NSObject {
         // Safety check: prevent storing a messageId older than the thread's first message as block's oldestMessageId when in a thread controller
         let oldestMessageKnown = (isThreadController && lastKnown < threadId) ? threadId : lastKnown
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             let managedSortedBlocks = self.managedSortedBlocksForRoomOrThread()
 
             // Create new chat block
@@ -397,8 +392,7 @@ public class NCChatController: NSObject {
     }
 
     private func updateHistoryFlagInFirstBlock() {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             let managedSortedBlocks = self.managedSortedBlocksForRoomOrThread()
             let firstChatBlock = managedSortedBlocks.firstObject() as? NCChatBlock
             firstChatBlock?.hasHistory = false
@@ -406,8 +400,7 @@ public class NCChatController: NSObject {
     }
 
     private func transactionForMessage(withReferenceId referenceId: String, block: @escaping (_ message: NCChatMessage?) -> Void) {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             let managedChatMessage = NCChatMessage.objects(where: "referenceId = %@ AND isTemporary = true", referenceId).firstObject() as? NCChatMessage
             block(managedChatMessage)
         }
@@ -744,8 +737,7 @@ public class NCChatController: NSObject {
         let twelveHoursAgoTimestamp = Int(Date().timeIntervalSince1970) - (60 * 60 * 12)
 
         for case let temporaryMessage as NCChatMessage in managedTemporaryMessages where temporaryMessage.timestamp < twelveHoursAgoTimestamp {
-            let realm = RLMRealm.default()
-            try? realm.transaction {
+            RLMRealm.writeTransaction { _ in
                 temporaryMessage.isOfflineMessage = false
                 temporaryMessage.sendingFailed = true
             }

--- a/NextcloudTalk/Database/NCDatabaseManager.swift
+++ b/NextcloudTalk/Database/NCDatabaseManager.swift
@@ -886,17 +886,30 @@ public extension Notification.Name {
     }
 
     func updateConversationTags(_ tags: [NCConversationTag], forAccountId accountId: String) {
+        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateConversationTagsForAccountId", expirationHandler: nil)
         let realm = RLMRealm.default()
 
         try? realm.transaction {
+            if bgTask.isExpired {
+                realm.cancelWriteTransaction()
+                return
+            }
+
             let query = NSPredicate(format: "accountId = %@", accountId)
             realm.deleteObjects(NCConversationTag.objects(with: query))
 
             for tag in tags {
+                if bgTask.isExpired {
+                    realm.cancelWriteTransaction()
+                    return
+                }
+
                 // Add a copy, so the passed objects stay unmanaged for the caller
                 realm.add(NCConversationTag(value: tag))
             }
         }
+
+        bgTask.stopBackgroundTask()
     }
 }
 

--- a/NextcloudTalk/Database/NCDatabaseManager.swift
+++ b/NextcloudTalk/Database/NCDatabaseManager.swift
@@ -227,16 +227,30 @@ public extension Notification.Name {
         return nil
     }
 
-    public func setActiveAccountWithAccountId(_ accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        for case let account as TalkAccount in TalkAccount.allObjects() {
-            account.active = false
+    /// Runs `block` on the managed `TalkAccount` with the given `accountId`, inside a write transaction.
+    ///
+    /// The account passed to `block` is managed, so changes to it are persisted when the transaction
+    /// commits. Does nothing when there's no account with that id.
+    @nonobjc
+    public func updateTalkAccount(forAccountId accountId: String, _ name: String = #function, _ block: (TalkAccount) -> Void) {
+        RLMRealm.writeTransaction(name) { _ in
+            guard let managedAccount = TalkAccount.objects(where: "accountId = %@", accountId).firstObject() as? TalkAccount else { return }
+
+            block(managedAccount)
         }
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        let activeAccount = TalkAccount.objects(with: query).firstObject() as? TalkAccount
-        activeAccount?.active = true
-        try? realm.commitWriteTransaction()
+    }
+
+    public func setActiveAccountWithAccountId(_ accountId: String) {
+        RLMRealm.writeTransaction { _ in
+            for case let account as TalkAccount in TalkAccount.allObjects() {
+                account.active = false
+            }
+
+            let query = NSPredicate(format: "accountId = %@", accountId)
+            let activeAccount = TalkAccount.objects(with: query).firstObject() as? TalkAccount
+            activeAccount?.active = true
+        }
+
         NCLog.log("Set active account to \(accountId)")
     }
 
@@ -250,81 +264,64 @@ public extension Notification.Name {
         account.server = server
         account.user = user
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             realm.add(account)
         }
     }
 
     public func removeAccount(withAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let isLastAccount = numberOfAccounts() == 1
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let removeAccount = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            realm.delete(removeAccount)
+        RLMRealm.writeTransaction { realm in
+            let isLastAccount = self.numberOfAccounts() == 1
+            let query = NSPredicate(format: "accountId = %@", accountId)
+            if let removeAccount = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
+                realm.delete(removeAccount)
+            }
+            if let serverCapabilities = ServerCapabilities.objects(with: query).firstObject() as? ServerCapabilities {
+                realm.delete(serverCapabilities)
+                self.capabilitiesCache.removeObject(forKey: accountId as NSString)
+                self.talkCapabilitiesCache.removeAllObjects()
+            }
+            realm.deleteObjects(NCRoom.objects(with: query))
+            realm.deleteObjects(NCChatMessage.objects(with: query))
+            realm.deleteObjects(NCChatBlock.objects(with: query))
+            realm.deleteObjects(NCThread.objects(with: query))
+            realm.deleteObjects(NCContact.objects(with: query))
+            realm.deleteObjects(FederatedCapabilities.objects(with: query))
+            realm.deleteObjects(NCConversationTag.objects(with: query))
+            if isLastAccount {
+                realm.deleteObjects(ABContact.allObjects())
+            }
         }
-        if let serverCapabilities = ServerCapabilities.objects(with: query).firstObject() as? ServerCapabilities {
-            realm.delete(serverCapabilities)
-            capabilitiesCache.removeObject(forKey: accountId as NSString)
-            talkCapabilitiesCache.removeAllObjects()
-        }
-        realm.deleteObjects(NCRoom.objects(with: query))
-        realm.deleteObjects(NCChatMessage.objects(with: query))
-        realm.deleteObjects(NCChatBlock.objects(with: query))
-        realm.deleteObjects(NCThread.objects(with: query))
-        realm.deleteObjects(NCContact.objects(with: query))
-        realm.deleteObjects(FederatedCapabilities.objects(with: query))
-        realm.deleteObjects(NCConversationTag.objects(with: query))
-        if isLastAccount {
-            realm.deleteObjects(ABContact.allObjects())
-        }
-        try? realm.commitWriteTransaction()
     }
 
     public func removeStoredMessages(forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        realm.deleteObjects(NCChatMessage.objects(with: query))
-        realm.deleteObjects(NCChatBlock.objects(with: query))
-        realm.deleteObjects(NCThread.objects(with: query))
-        try? realm.commitWriteTransaction()
+        RLMRealm.writeTransaction { realm in
+            let query = NSPredicate(format: "accountId = %@", accountId)
+            realm.deleteObjects(NCChatMessage.objects(with: query))
+            realm.deleteObjects(NCChatBlock.objects(with: query))
+            realm.deleteObjects(NCThread.objects(with: query))
+        }
     }
 
     public func increaseUnreadBadgeNumber(forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
+        updateTalkAccount(forAccountId: accountId) { account in
             account.unreadBadgeNumber += 1
             account.unreadNotification = true
         }
-        try? realm.commitWriteTransaction()
     }
 
     public func decreaseUnreadBadgeNumber(forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
+        updateTalkAccount(forAccountId: accountId) { account in
             account.unreadBadgeNumber = (account.unreadBadgeNumber > 0) ? account.unreadBadgeNumber - 1 : 0
             account.unreadNotification = (account.unreadBadgeNumber > 0) ? account.unreadNotification : false
         }
-        try? realm.commitWriteTransaction()
     }
 
     public func resetUnreadBadgeNumber(forAccountId accountId: String) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "resetUnreadBadgeNumberForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
+        updateTalkAccount(forAccountId: accountId) { account in
             account.unreadBadgeNumber = 0
             account.unreadNotification = false
         }
-        try? realm.commitWriteTransaction()
-        bgTask.stopBackgroundTask()
     }
 
     public func numberOfInactiveAccountsWithUnreadNotifications() -> Int {
@@ -344,63 +341,30 @@ public extension Notification.Name {
     }
 
     public func removeUnreadNotificationForInactiveAccounts() {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        for case let account as TalkAccount in TalkAccount.allObjects() {
-            account.unreadNotification = false
+        RLMRealm.writeTransaction { _ in
+            for case let account as TalkAccount in TalkAccount.allObjects() {
+                account.unreadNotification = false
+            }
         }
-        try? realm.commitWriteTransaction()
     }
 
     public func updateTalkConfigurationHash(forAccountId accountId: String, withHash hash: String) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateTalkConfigurationHashForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.lastReceivedConfigurationHash = hash
-        }
-        try? realm.commitWriteTransaction()
-        bgTask.stopBackgroundTask()
+        updateTalkAccount(forAccountId: accountId) { $0.lastReceivedConfigurationHash = hash }
     }
 
     public func updateLastModifiedSince(forAccountId accountId: String, with modifiedSince: String) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateLastModifiedSinceForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.lastReceivedModifiedSince = modifiedSince
-        }
-        try? realm.commitWriteTransaction()
-        bgTask.stopBackgroundTask()
+        updateTalkAccount(forAccountId: accountId) { $0.lastReceivedModifiedSince = modifiedSince }
     }
 
     public func updateHasThreads(forAccountId accountId: String, with hasThreads: Bool) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateHasThreadsForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.hasThreads = hasThreads
-        }
-        try? realm.commitWriteTransaction()
-        bgTask.stopBackgroundTask()
+        updateTalkAccount(forAccountId: accountId) { $0.hasThreads = hasThreads }
 
         let userInfo: [String: Any] = ["accountId": accountId, "hasThreads": hasThreads]
         NotificationCenter.default.post(name: .NCUserHasThreadsFlagUpdated, object: self, userInfo: userInfo)
     }
 
     public func updateThreadsLastCheckTimestamp(forAccountId accountId: String, with lastCheckTimestamp: Int) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateHasThreadsLastCheckTimestampForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.threadsLastCheckTimestamp = lastCheckTimestamp
-        }
-        try? realm.commitWriteTransaction()
-        bgTask.stopBackgroundTask()
+        updateTalkAccount(forAccountId: accountId) { $0.threadsLastCheckTimestamp = lastCheckTimestamp }
     }
 
     // MARK: - Rooms
@@ -528,8 +492,7 @@ public extension Notification.Name {
 
         talkCapabilitiesCache.removeAllObjects()
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             realm.addOrUpdate(federatedCapabilities)
 
             // Update the hash
@@ -665,8 +628,7 @@ public extension Notification.Name {
             setTalkCapabilities(talkCaps, onTalkCapabilitiesObject: capabilities)
         }
 
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { realm in
             realm.addOrUpdate(capabilities)
         }
 
@@ -703,16 +665,15 @@ public extension Notification.Name {
     }
 
     public func setExternalSignalingServerVersion(_ version: String, forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             let query = NSPredicate(format: "accountId = %@", accountId)
             if let managedServerCapabilities = ServerCapabilities.objects(with: query).firstObject() as? ServerCapabilities,
                managedServerCapabilities.externalSignalingServerVersion != version {
                 managedServerCapabilities.externalSignalingServerVersion = version
 
                 let unmanagedServerCapabilities = ServerCapabilities(value: managedServerCapabilities)
-                capabilitiesCache.setObject(unmanagedServerCapabilities, forKey: accountId as NSString)
-                talkCapabilitiesCache.removeAllObjects()
+                self.capabilitiesCache.setObject(unmanagedServerCapabilities, forKey: accountId as NSString)
+                self.talkCapabilitiesCache.removeAllObjects()
             }
         }
     }
@@ -763,35 +724,19 @@ public extension Notification.Name {
     // MARK: - Federation invitations
 
     public func increasePendingFederationInvitation(forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.pendingFederationInvitations += 1
-        }
-        try? realm.commitWriteTransaction()
+        updateTalkAccount(forAccountId: accountId) { $0.pendingFederationInvitations += 1 }
     }
 
     public func decreasePendingFederationInvitation(forAccountId accountId: String) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
+        updateTalkAccount(forAccountId: accountId) { account in
             account.pendingFederationInvitations = (account.pendingFederationInvitations > 0) ? account.pendingFederationInvitations - 1 : 0
         }
-        try? realm.commitWriteTransaction()
 
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: NCDatabaseManagerPendingFederationInvitationsDidChange), object: self, userInfo: nil)
     }
 
     public func setPendingFederationInvitationForAccountId(_ accountId: String, with numberOfPendingInvitations: Int) {
-        let realm = RLMRealm.default()
-        realm.beginWriteTransaction()
-        let query = NSPredicate(format: "accountId = %@", accountId)
-        if let account = TalkAccount.objects(with: query).firstObject() as? TalkAccount {
-            account.pendingFederationInvitations = numberOfPendingInvitations
-        }
-        try? realm.commitWriteTransaction()
+        updateTalkAccount(forAccountId: accountId) { $0.pendingFederationInvitations = numberOfPendingInvitations }
 
         NotificationCenter.default.post(name: NSNotification.Name(rawValue: NCDatabaseManagerPendingFederationInvitationsDidChange), object: self, userInfo: nil)
     }
@@ -822,13 +767,7 @@ public extension Notification.Name {
               let jsonString = String(data: jsonData, encoding: .utf8)
         else { return }
 
-        let realm = RLMRealm.default()
-
-        try? realm.transaction {
-            if let managedTalkAccount = TalkAccount.objects(where: "accountId = %@", account.accountId).firstObject() as? TalkAccount {
-                managedTalkAccount.frequentlyUsedEmojisJSONString = jsonString
-            }
-        }
+        updateTalkAccount(forAccountId: account.accountId) { $0.frequentlyUsedEmojisJSONString = jsonString }
     }
 
     // MARK: - Rooms
@@ -886,30 +825,15 @@ public extension Notification.Name {
     }
 
     func updateConversationTags(_ tags: [NCConversationTag], forAccountId accountId: String) {
-        let bgTask = BGTaskHelper.startBackgroundTask(withName: "updateConversationTagsForAccountId", expirationHandler: nil)
-        let realm = RLMRealm.default()
-
-        try? realm.transaction {
-            if bgTask.isExpired {
-                realm.cancelWriteTransaction()
-                return
-            }
-
+        RLMRealm.writeTransaction { realm in
             let query = NSPredicate(format: "accountId = %@", accountId)
             realm.deleteObjects(NCConversationTag.objects(with: query))
 
             for tag in tags {
-                if bgTask.isExpired {
-                    realm.cancelWriteTransaction()
-                    return
-                }
-
                 // Add a copy, so the passed objects stay unmanaged for the caller
                 realm.add(NCConversationTag(value: tag))
             }
         }
-
-        bgTask.stopBackgroundTask()
     }
 }
 

--- a/NextcloudTalk/Database/RLMRealm+Transaction.swift
+++ b/NextcloudTalk/Database/RLMRealm+Transaction.swift
@@ -1,0 +1,36 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import Foundation
+
+extension RLMRealm {
+
+    /// Runs `block` in a write transaction on the current thread's default realm.
+    ///
+    /// The transaction is wrapped in a background task, so iOS does not suspend us while the realm
+    /// write lock is held, which would terminate the app.
+    ///
+    /// `name` defaults to the calling function and is used to name the background task and to report
+    /// a failing transaction, so there's no need to pass it explicitly.
+    @discardableResult
+    static func writeTransaction<T>(_ name: String = #function, _ block: (RLMRealm) -> T) -> T? {
+        let bgTask = BGTaskHelper.startBackgroundTask(withName: name)
+        defer { bgTask.stopBackgroundTask() }
+
+        let realm = RLMRealm.default()
+        var result: T?
+
+        do {
+            try realm.transaction {
+                result = block(realm)
+            }
+        } catch {
+            NCLog.log("Realm write transaction failed in \(name): \(error.localizedDescription)")
+            return nil
+        }
+
+        return result
+    }
+}

--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -3482,7 +3482,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
             var hasCustomAvatar = false
 
-            try? RLMRealm.default().transaction {
+            RLMRealm.writeTransaction { _ in
                 let query = NSPredicate(format: "accountId = %@", account.accountId)
                 if let customHeader = response.value(forHTTPHeaderField: "X-NC-IsCustomAvatar"),
                    let managedAccount = TalkAccount.objects(with: query).firstObject() as? TalkAccount {

--- a/NextcloudTalk/Rooms/NCRoomsManager.swift
+++ b/NextcloudTalk/Rooms/NCRoomsManager.swift
@@ -248,8 +248,7 @@ class NCRoomsManager: NSObject, CallViewControllerDelegate {
                 return
             }
 
-            let realm = RLMRealm.default()
-            try? realm.transaction {
+            RLMRealm.writeTransaction { realm in
                 self.updateRoom(withDict: roomDict, withAccount: account, withTimestamp: Int(Date().timeIntervalSince1970), withRealm: realm)
             }
 
@@ -307,13 +306,11 @@ class NCRoomsManager: NSObject, CallViewControllerDelegate {
     }
 
     private func updateRoom(_ room: NCRoom, withBlock block: @escaping (_ managedRoom: NCRoom) -> Void) {
-        let bgTask = BGTaskHelper.startBackgroundTask()
-        try? RLMRealm.default().transaction {
+        RLMRealm.writeTransaction { _ in
             if let managedRoom = NCRoom.objects(where: "internalId = %@", room.internalId).firstObject() as? NCRoom {
                 block(managedRoom)
             }
         }
-        bgTask.stopBackgroundTask()
     }
 
     public func updatePendingMessage(_ message: String, forRoom room: NCRoom) {
@@ -1299,14 +1296,13 @@ class NCRoomsManager: NSObject, CallViewControllerDelegate {
             query = NSPredicate(format: "isOfflineMessage = true")
         }
 
-        let realm = RLMRealm.default()
         let managedTemporaryMessages = NCChatMessage.objects(with: query)
         let twelveHoursAgoTimestamp = Int(Date().timeIntervalSince1970 - (60 * 60 * 12))
 
         for case let offlineMessage as NCChatMessage in managedTemporaryMessages {
             // If we were unable to send a message after 12 hours, mark as failed
             if offlineMessage.timestamp < twelveHoursAgoTimestamp {
-                try? realm.transaction {
+                RLMRealm.writeTransaction { _ in
                     offlineMessage.isOfflineMessage = false
                     offlineMessage.sendingFailed = true
                 }

--- a/NextcloudTalk/Settings/NCSettingsController.swift
+++ b/NextcloudTalk/Settings/NCSettingsController.swift
@@ -95,8 +95,7 @@ public class NCSettingsController: NSObject {
 
     private func resetPerAppLaunchSettings() {
         // Reset "threadsLastCheckTimestamp" on every app fresh launch
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             for case let account as TalkAccount in TalkAccount.allObjects() {
                 account.threadsLastCheckTimestamp = 0
             }
@@ -285,8 +284,7 @@ public class NCSettingsController: NSObject {
         // Migration from global setting to per-account setting
         if (UserDefaults.standard.object(forKey: kContactSyncEnabled) as? NSNumber)?.boolValue == true {
             // If global setting was enabled then we enable contact sync for all accounts
-            let realm = RLMRealm.default()
-            try? realm.transaction {
+            RLMRealm.writeTransaction { _ in
                 for case let account as TalkAccount in TalkAccount.allObjects() {
                     account.hasContactSyncEnabled = true
                 }
@@ -301,8 +299,7 @@ public class NCSettingsController: NSObject {
     }
 
     public func setContactSync(_ enabled: Bool) {
-        let realm = RLMRealm.default()
-        try? realm.transaction {
+        RLMRealm.writeTransaction { _ in
             let account = TalkAccount.objects(where: "active = true").firstObject() as? TalkAccount
             account?.hasContactSyncEnabled = enabled
         }
@@ -333,9 +330,7 @@ public class NCSettingsController: NSObject {
 
             let email = (userProfile[UserProfileField.email] as? String) ?? ""
 
-            let bgTask = BGTaskHelper.startBackgroundTask(withName: "NCSetUserProfile")
-            let realm = RLMRealm.default()
-            try? realm.transaction {
+            RLMRealm.writeTransaction("NCSetUserProfile") { _ in
                 guard let managedActiveAccount = TalkAccount.objects(where: "accountId = %@", account.accountId).firstObject() as? TalkAccount else {
                     block(OcsError.genericError())
                     return
@@ -363,7 +358,6 @@ public class NCSettingsController: NSObject {
 
                 block(nil)
             }
-            bgTask.stopBackgroundTask()
         }
     }
 
@@ -378,17 +372,10 @@ public class NCSettingsController: NSObject {
                 return
             }
 
-            let bgTask = BGTaskHelper.startBackgroundTask(withName: "NCSetUserGroups")
-            let realm = RLMRealm.default()
-            try? realm.transaction {
-                guard let managedActiveAccount = TalkAccount.objects(where: "accountId = %@", account.accountId).firstObject() as? TalkAccount else {
-                    return
-                }
-
+            NCDatabaseManager.sharedInstance().updateTalkAccount(forAccountId: account.accountId, "NCSetUserGroups") { managedActiveAccount in
                 managedActiveAccount.groupIds.removeAllObjects()
                 managedActiveAccount.groupIds.addObjects((groupIds ?? []) as NSArray)
             }
-            bgTask.stopBackgroundTask()
         }
 
         NCAPIController.sharedInstance().getUserTeams(forAccount: account) { teamIds, error in
@@ -397,17 +384,10 @@ public class NCSettingsController: NSObject {
                 return
             }
 
-            let bgTask = BGTaskHelper.startBackgroundTask(withName: "NCSetUserTeams")
-            let realm = RLMRealm.default()
-            try? realm.transaction {
-                guard let managedActiveAccount = TalkAccount.objects(where: "accountId = %@", account.accountId).firstObject() as? TalkAccount else {
-                    return
-                }
-
+            NCDatabaseManager.sharedInstance().updateTalkAccount(forAccountId: account.accountId, "NCSetUserTeams") { managedActiveAccount in
                 managedActiveAccount.teamIds.removeAllObjects()
                 managedActiveAccount.teamIds.addObjects((teamIds ?? []) as NSArray)
             }
-            bgTask.stopBackgroundTask()
         }
     }
 
@@ -703,13 +683,11 @@ public class NCSettingsController: NSObject {
                 return
             }
 
-            let realm = RLMRealm.default()
-            realm.beginWriteTransaction()
-            let managedAccount = TalkAccount.objects(where: "accountId = %@", accountId).firstObject() as? TalkAccount
-            managedAccount?.userPublicKey = publicKey
-            managedAccount?.deviceIdentifier = deviceIdentifier
-            managedAccount?.deviceSignature = signature
-            try? realm.commitWriteTransaction()
+            NCDatabaseManager.sharedInstance().updateTalkAccount(forAccountId: accountId) { managedAccount in
+                managedAccount.userPublicKey = publicKey
+                managedAccount.deviceIdentifier = deviceIdentifier
+                managedAccount.deviceSignature = signature
+            }
 
             NCAPIController.sharedInstance().subscribeAccount(account, toPushServerWithCompletionBlock: { error in
                 guard error == nil else {
@@ -723,11 +701,8 @@ public class NCSettingsController: NSObject {
                     return
                 }
 
-                let realm = RLMRealm.default()
-                realm.beginWriteTransaction()
-                let managedAccount = TalkAccount.objects(where: "accountId = %@", accountId).firstObject() as? TalkAccount
-                managedAccount?.lastPushSubscription = Int(Date().timeIntervalSince1970)
-                try? realm.commitWriteTransaction()
+                NCDatabaseManager.sharedInstance().updateTalkAccount(forAccountId: accountId) { $0.lastPushSubscription = Int(Date().timeIntervalSince1970) }
+
                 NCKeyChainController.sharedInstance().setPushNotificationPublicKey(keyPair.publicKey, forAccountId: accountId)
                 NCKeyChainController.sharedInstance().setPushNotificationPrivateKey(keyPair.privateKey, forAccountId: accountId)
                 NCLog.log("Subscribed to Push Notification server successfully.")


### PR DESCRIPTION
Every realm write should run inside a background assertion, so iOS does not
suspend us while the realm write lock is held. The realm lives in the shared
app group container, so being suspended holding its lock is a kill. That was
open-coded at every call site, and about half the write sites were missing it.

`RLMRealm.writeTransaction` now does it in one place, releasing the assertion
with a `defer`, and `NCDatabaseManager.updateTalkAccount(forAccountId:)` covers
the common "change one field on the account" case.

`NCRoomsManager.updateRooms` is left as it is: it loops over every room on the
account, which can be hundreds, each with nested deletes. It is the only write
that could realistically run out of background time and need to bail out mid
transaction, so it keeps its own background task and `cancelWriteTransaction()`.
Everywhere else the block is a few statements, `updateConversationTags`
included — which is why its per item expiration checks are gone.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
