### PR TITLE
fix: Retain realm instance to prevent continious open/close locking

### DIFF
--- a/NextcloudTalk/Database/NCDatabaseManager.swift
+++ b/NextcloudTalk/Database/NCDatabaseManager.swift
@@ -134,6 +134,11 @@ public extension Notification.Name {
     /// Derived from the server and federated capabilities, so dropped whenever either is written
     private let talkCapabilitiesCache = NSCache<NSString, TalkCapabilities>()
 
+#if !APP_EXTENSION
+    /// Keeps the database open for the lifetime of the app, see `init`
+    private var retainedRealm: RLMRealm?
+#endif
+
     public class func sharedInstance() -> NCDatabaseManager {
         return shared
     }
@@ -171,6 +176,16 @@ public extension Notification.Name {
         // Now that we've told Realm how to handle the schema change, opening the file
         // will automatically perform the migration
         _ = RLMRealm.default()
+
+#if !APP_EXTENSION
+        // Realm caches its instances weakly, so holding one keeps the database open instead of every access
+        // reopening and closing the file, which also avoids the file lock that closing takes (0xdead10cc).
+        // It has to be a main thread realm, as only those auto refresh and therefore don't pin the version
+        // they were opened with, which would grow the file.
+        DispatchQueue.main.async {
+            self.retainedRealm = RLMRealm.default()
+        }
+#endif
 
 #if DEBUG
         // Copy Talk DB to Documents directory


### PR DESCRIPTION
Tried to debug some realm crashes that were reported on appstore connect, but did not show a clear path. The theory is, that these crashes happen on open/closing of Realm as that (besides transactions) is the only place where a lockfile is used. Closing happens, when the instance is deallocated. It should be fine to not do that at all on the main thread, so we reatain an instance, to prevent the lockfiles on open/close.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
