### PR TITLE
fix: Handle errors in internal signaling more gracefully

### DIFF
--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -1510,6 +1510,13 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
         }
     }
 
+    func signalingControllerSessionExpired(_ signalingController: NCSignalingController!) {
+        NCLog.log("Internal signaling session expired for \(self.room.token), ending call")
+
+        // The join failure path already shows the reason in the foreground and ends via CallKit in the background
+        self.delegate?.callControllerDidFailedJoiningCall(self, statusCode: 404, errorReason: self.getJoinCallErrorReason(404))
+    }
+
     // MARK: - NCCameraController delegate
 
     func didDrawFirstFrameOnLocalView() {

--- a/NextcloudTalk/WebRTC/NCSignalingController.h
+++ b/NextcloudTalk/WebRTC/NCSignalingController.h
@@ -15,6 +15,11 @@
 
 - (void)signalingController:(NCSignalingController *)signalingController didReceiveSignalingMessage:(NSDictionary *)message;
 
+@optional
+
+// The server no longer knows our session in this room, which polling cannot recover from
+- (void)signalingControllerSessionExpired:(NCSignalingController *)signalingController;
+
 @end
 
 typedef void (^SignalingSettingsUpdatedCompletionBlock)(SignalingSettings *signalingSettings);

--- a/NextcloudTalk/WebRTC/NCSignalingController.m
+++ b/NextcloudTalk/WebRTC/NCSignalingController.m
@@ -15,12 +15,17 @@
 {
     NCRoom *_room;
     BOOL _shouldStopPullingMessages;
+    NSInteger _consecutivePullFailures;
+    NSInteger _consecutiveSessionGoneFailures;
     SignalingSettings *_signalingSettings;
     NSURLSessionTask *_getSignalingSettingsTask;
     NSURLSessionTask *_pullSignalingMessagesTask;
 }
 
 @end
+
+// About 45s of retrying with the backoff below
+static NSInteger const kMaxConsecutiveSessionGoneFailures = 5;
 
 @implementation NCSignalingController
 
@@ -92,6 +97,8 @@
     [NCLog log:[NSString stringWithFormat:@"Start pulling internal signaling messages for token %@", _room.token]];
 
     _shouldStopPullingMessages = NO;
+    _consecutivePullFailures = 0;
+    _consecutiveSessionGoneFailures = 0;
     [self pullSignalingMessages];
 }
 
@@ -107,6 +114,47 @@
         if (self->_shouldStopPullingMessages) {
             return;
         }
+
+        if (error) {
+            self->_consecutivePullFailures += 1;
+
+            // A 404 means our session is gone server side, which polling cannot recover from
+            if (error.responseStatusCode == 404) {
+                self->_consecutiveSessionGoneFailures += 1;
+
+                if (self->_consecutiveSessionGoneFailures >= kMaxConsecutiveSessionGoneFailures) {
+                    [NCLog log:[NSString stringWithFormat:@"Internal signaling has no session for token %@ anymore, ending the call", self->_room.token]];
+
+                    self->_shouldStopPullingMessages = YES;
+
+                    if ([self.observer respondsToSelector:@selector(signalingControllerSessionExpired:)]) {
+                        [self.observer signalingControllerSessionExpired:self];
+                    }
+
+                    return;
+                }
+            } else {
+                self->_consecutiveSessionGoneFailures = 0;
+            }
+
+            // The request is only re-armed from here, so retrying immediately would busy loop
+            NSTimeInterval delay = MIN(pow(2, MIN(self->_consecutivePullFailures, 4)), 16);
+
+            [NCLog log:[NSString stringWithFormat:@"Could not pull internal signaling messages (failure %ld, status %ld), retrying in %.0fs", (long)self->_consecutivePullFailures, (long)error.responseStatusCode, delay]];
+
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                if (self->_shouldStopPullingMessages) {
+                    return;
+                }
+
+                [self pullSignalingMessages];
+            });
+
+            return;
+        }
+
+        self->_consecutivePullFailures = 0;
+        self->_consecutiveSessionGoneFailures = 0;
 
         for (NSDictionary *message in messages) {
             if ([self.observer respondsToSelector:@selector(signalingController:didReceiveSignalingMessage:)]) {


### PR DESCRIPTION
* Additional safe-guard for https://github.com/nextcloud/talk-ios/issues/2652. No need to hammer a server on error.

Backport will conflict due to swift migration, would only keep it on 25+, since it is really just a safe-guard.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
