### PR TITLE
fix: Typo in thread endpoint parameter

### DIFF
--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -1647,7 +1647,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
         let parameters: [String: Any] = [
             "limit": limit,
-            "offfset": offset
+            "offset": offset
         ]
 
         apiSessionManager.getOcs(urlString, account: account, parameters: parameters) { ocsResponse, ocsError in


### PR DESCRIPTION

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
