### PR TITLE
fix: Align the conversation tags row with the conversation list

### DIFF
--- a/NextcloudTalk/Chat/Chat views/Reactions/ReactionsView.swift
+++ b/NextcloudTalk/Chat/Chat views/Reactions/ReactionsView.swift
@@ -17,18 +17,7 @@ import UIKit
     /// Spacing between two reactions
     private static let itemSpacing: CGFloat = 8
 
-    /// Width of the fade shown at an edge that has more reactions behind it
-    private static let scrollFadeWidth: CGFloat = 16
-
     private let feedbackGenerator = UIImpactFeedbackGenerator(style: .light)
-
-    private lazy var scrollFadeLayer: CAGradientLayer = {
-        let fadeLayer = CAGradientLayer()
-        fadeLayer.startPoint = .init(x: 0, y: 0.5)
-        fadeLayer.endPoint = .init(x: 1, y: 0.5)
-
-        return fadeLayer
-    }()
 
     /// Tracks the touch start time to differentiate quick taps from long presses
     private var touchBeganTime: Date?
@@ -85,35 +74,7 @@ import UIKit
         super.layoutSubviews()
 
         // Also called while scrolling, so the fade follows the content offset
-        self.updateScrollFade()
-    }
-
-    /// Fades out an edge that can be scrolled towards, so it is visible that there are more reactions
-    private func updateScrollFade() {
-        guard self.bounds.width > 0 else { return }
-
-        let canScrollToLeading = self.contentOffset.x > 1
-        let canScrollToTrailing = self.contentOffset.x + self.bounds.width < self.contentSize.width - 1
-
-        guard canScrollToLeading || canScrollToTrailing else {
-            self.layer.mask = nil
-            return
-        }
-
-        let fadeLayer = self.scrollFadeLayer
-        self.layer.mask = fadeLayer
-
-        let opaque = UIColor.white.cgColor
-        let clear = UIColor.clear.cgColor
-        let fade = min(ReactionsView.scrollFadeWidth, self.bounds.width / 3) / self.bounds.width
-
-        // The mask is part of the scroll view's layer, so it has to be moved along with the content
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        fadeLayer.frame = .init(origin: self.contentOffset, size: self.bounds.size)
-        fadeLayer.colors = [canScrollToLeading ? clear : opaque, opaque, opaque, canScrollToTrailing ? clear : opaque]
-        fadeLayer.locations = [0, NSNumber(value: fade), NSNumber(value: 1 - fade), 1]
-        CATransaction.commit()
+        self.updateHorizontalScrollFade()
     }
 
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {

--- a/NextcloudTalk/Rooms/RoomTagsFilterView.swift
+++ b/NextcloudTalk/Rooms/RoomTagsFilterView.swift
@@ -116,6 +116,7 @@ class RoomTagsFilterView: UIView {
         guard let chip = sender.chip else { return }
 
         feedbackGenerator.selectionChanged()
+        scrollView.scrollToVisible(sender)
         onChipSelected?(chip.id)
     }
 }

--- a/NextcloudTalk/Rooms/RoomTagsFilterView.swift
+++ b/NextcloudTalk/Rooms/RoomTagsFilterView.swift
@@ -33,6 +33,7 @@ class RoomTagsFilterView: UIView {
 
     static let chipVerticalPadding: CGFloat = PillShapeMetrics.verticalPadding
     static let rowVerticalPadding: CGFloat = 16
+    static let rowHorizontalPadding: CGFloat = 16
 
     // Adapts to the current dynamic type size of the chip title font
     static var viewHeight: CGFloat {
@@ -43,7 +44,7 @@ class RoomTagsFilterView: UIView {
     public var onChipSelected: ((String) -> Void)?
     public var onChipLongPressed: (() -> Void)?
 
-    private let scrollView = UIScrollView()
+    private let scrollView = FadingScrollView()
     private let stackView = UIStackView()
     private let feedbackGenerator = UISelectionFeedbackGenerator()
     private var chips: [TagFilterChip] = []
@@ -70,13 +71,13 @@ class RoomTagsFilterView: UIView {
         scrollView.addSubview(stackView)
 
         NSLayoutConstraint.activate([
-            scrollView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.leadingAnchor, constant: Self.rowHorizontalPadding),
+            scrollView.trailingAnchor.constraint(equalTo: self.safeAreaLayoutGuide.trailingAnchor, constant: -Self.rowHorizontalPadding),
             scrollView.topAnchor.constraint(equalTo: self.topAnchor),
             scrollView.bottomAnchor.constraint(equalTo: self.bottomAnchor),
 
-            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor, constant: 16),
-            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor, constant: -16),
+            stackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            stackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
             stackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor, constant: Self.rowVerticalPadding),
             stackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor, constant: -Self.rowVerticalPadding),
             stackView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor, constant: -(Self.rowVerticalPadding * 2))
@@ -96,6 +97,7 @@ class RoomTagsFilterView: UIView {
             chipControl.addGestureRecognizer(UILongPressGestureRecognizer(target: self, action: #selector(chipLongPressed(_:))))
             stackView.addArrangedSubview(chipControl)
         }
+
     }
 
     @objc private func chipLongPressed(_ recognizer: UILongPressGestureRecognizer) {

--- a/NextcloudTalk/User Interface/ScrollViewFade.swift
+++ b/NextcloudTalk/User Interface/ScrollViewFade.swift
@@ -1,0 +1,57 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import UIKit
+
+extension UIScrollView {
+
+    /// Fades out a horizontal edge that can be scrolled towards, so it is visible that there is more content.
+    /// Call this from `layoutSubviews`, which is also run while scrolling.
+    func updateHorizontalScrollFade(fadeWidth: CGFloat = 16) {
+        guard self.bounds.width > 0 else { return }
+
+        let minOffset = -self.adjustedContentInset.left
+        let maxOffset = self.contentSize.width + self.adjustedContentInset.right - self.bounds.width
+
+        let canScrollToLeading = self.contentOffset.x > minOffset + 1
+        let canScrollToTrailing = self.contentOffset.x < maxOffset - 1
+
+        guard canScrollToLeading || canScrollToTrailing else {
+            self.layer.mask = nil
+            return
+        }
+
+        let fadeLayer = self.layer.mask as? CAGradientLayer ?? {
+            let gradientLayer = CAGradientLayer()
+            gradientLayer.startPoint = .init(x: 0, y: 0.5)
+            gradientLayer.endPoint = .init(x: 1, y: 0.5)
+            self.layer.mask = gradientLayer
+
+            return gradientLayer
+        }()
+
+        let opaque = UIColor.white.cgColor
+        let clear = UIColor.clear.cgColor
+        let fade = min(fadeWidth, self.bounds.width / 3) / self.bounds.width
+
+        // Scroll views scroll by moving their bounds origin, so using the bounds here keeps the
+        // mask in place while the content moves underneath it
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        fadeLayer.frame = self.bounds
+        fadeLayer.colors = [canScrollToLeading ? clear : opaque, opaque, opaque, canScrollToTrailing ? clear : opaque]
+        fadeLayer.locations = [0, NSNumber(value: fade), NSNumber(value: 1 - fade), 1]
+        CATransaction.commit()
+    }
+}
+
+/// Scroll view that fades out a horizontal edge that can be scrolled towards
+class FadingScrollView: UIScrollView {
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        self.updateHorizontalScrollFade()
+    }
+}

--- a/NextcloudTalk/User Interface/ScrollViewFade.swift
+++ b/NextcloudTalk/User Interface/ScrollViewFade.swift
@@ -7,9 +7,12 @@ import UIKit
 
 extension UIScrollView {
 
+    /// Width of the fade shown at an edge that has more content behind it
+    static let horizontalFadeWidth: CGFloat = 16
+
     /// Fades out a horizontal edge that can be scrolled towards, so it is visible that there is more content.
     /// Call this from `layoutSubviews`, which is also run while scrolling.
-    func updateHorizontalScrollFade(fadeWidth: CGFloat = 16) {
+    func updateHorizontalScrollFade(fadeWidth: CGFloat = UIScrollView.horizontalFadeWidth) {
         guard self.bounds.width > 0 else { return }
 
         let minOffset = -self.adjustedContentInset.left
@@ -44,6 +47,13 @@ extension UIScrollView {
         fadeLayer.colors = [canScrollToLeading ? clear : opaque, opaque, opaque, canScrollToTrailing ? clear : opaque]
         fadeLayer.locations = [0, NSNumber(value: fade), NSNumber(value: 1 - fade), 1]
         CATransaction.commit()
+    }
+
+    /// Scrolls `view` into the visible area, keeping it clear of the fade at the edges
+    func scrollToVisible(_ view: UIView, fadeWidth: CGFloat = UIScrollView.horizontalFadeWidth, animated: Bool = true) {
+        let viewRect = view.convert(view.bounds, to: self)
+
+        self.scrollRectToVisible(viewRect.insetBy(dx: -fadeWidth, dy: 0), animated: animated)
     }
 }
 


### PR DESCRIPTION
| Before | After |
| --- | --- |
| <img width="1125" height="479" alt="IMG_E0373" src="https://github.com/user-attachments/assets/131593d6-6923-4c57-804e-803f4bad9da2" /> | <img width="1125" height="493" alt="IMG_E0374" src="https://github.com/user-attachments/assets/ee3f1c64-0104-4ccc-b9c2-2f60f4742755" /> |

### Additions
- Fades the edges when tags don't fit.
- Tapping a cut-off tag scrolls it into view.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
