### PR TITLE
fix: Resume voice message playback instead of restarting it

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -4103,11 +4103,7 @@ import Toast
             return
         }
 
-        if let fileStatus = fileParameter.fileStatus, fileStatus.fileLocalPath != nil && FileManager.default.fileExists(atPath: fileParameter.fileStatus?.fileLocalPath ?? "") {
-            self.setupVoiceMessagePlayer(with: fileParameter.fileStatus!)
-            return
-        }
-
+        // Resume an already loaded voice message
         if let voiceMessagesPlayer = self.voiceMessagesPlayer,
            let playerAudioFileStatus = self.playerAudioFileStatus,
            !voiceMessagesPlayer.isPlaying,
@@ -4115,6 +4111,15 @@ import Toast
            fileParameter.path == playerAudioFileStatus.filePath {
 
             self.playVoiceMessagePlayer()
+            return
+        }
+
+        // Temporary voice messages are played from their local file
+        if let fileStatus = fileParameter.fileStatus,
+           let fileLocalPath = fileStatus.fileLocalPath,
+           FileManager.default.fileExists(atPath: fileLocalPath) {
+
+            self.setupVoiceMessagePlayer(with: fileStatus)
             return
         }
 


### PR DESCRIPTION
`cellWants(toPlayAudioFile:)` checked for a local file before checking for an
already loaded player, so every play tap created a new `AVAudioPlayer` and
playback restarted from the beginning instead of resuming. The two checks are
now in the other order.

On main this was only reproducible with temporary voice messages (the ones still
being uploaded), because for messages coming from the server
`fileParameter.fileStatus` is never set since #2598. In 24.0.x it happens with
every voice message, so this needs a backport to stable24.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
