### PR TITLE
[stable24] fix: Resume voice message playback instead of restarting it

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -3944,11 +3944,7 @@ import Toast
             return
         }
 
-        if let fileStatus = fileParameter.fileStatus, fileStatus.fileLocalPath != nil && FileManager.default.fileExists(atPath: fileParameter.fileStatus?.fileLocalPath ?? "") {
-            self.setupVoiceMessagePlayer(with: fileParameter.fileStatus!)
-            return
-        }
-
+        // Resume an already loaded voice message
         if let voiceMessagesPlayer = self.voiceMessagesPlayer,
            let playerAudioFileStatus = self.playerAudioFileStatus,
            !voiceMessagesPlayer.isPlaying,
@@ -3956,6 +3952,15 @@ import Toast
            fileParameter.path == playerAudioFileStatus.filePath {
 
             self.playVoiceMessagePlayer()
+            return
+        }
+
+        // Temporary voice messages are played from their local file
+        if let fileStatus = fileParameter.fileStatus,
+           let fileLocalPath = fileStatus.fileLocalPath,
+           FileManager.default.fileExists(atPath: fileLocalPath) {
+
+            self.setupVoiceMessagePlayer(with: fileStatus)
             return
         }
 


### PR DESCRIPTION
Backport of #2692

* Fixes https://github.com/nextcloud/talk-ios/issues/2691

Note this affects every voice message on 24.0.x, while on main it was only
reproducible with voice messages that are still being uploaded.

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
