### PR TITLE
fix: iOS 27 adjustments

### DIFF
--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -3645,8 +3645,6 @@ import Toast
         }
     }
 
-    /// Uses a cell from the nib, not the one of the row: a cell which was displayed only renders the part of
-    /// a long message which was on screen, and handing over the live cell means UIKit reparents it
     internal func getContextMenuPreviewController(forRowAt indexPath: IndexPath) -> UIViewController? {
         guard let tableView = self.tableView,
               let message = self.message(for: indexPath),
@@ -3657,32 +3655,8 @@ import Toast
         previewCell.setup(for: message, inRoom: self.room, forThread: self.thread, withAccount: self.account)
         previewCell.layoutIfNeeded()
 
-        // Keeps the message out of the corners of the preview, which UIKit rounds stronger than our bubbles
-        let previewPadding = 12.0
-        let previewCellView = previewCell.contentView
-        let previewWidth = previewCellView.frame.width
-
-        // A preview wider than the cell is cut off instead of scaled, so the message makes room for the padding
-        let previewScale = (previewWidth - previewPadding * 2) / previewWidth
-
-        previewCellView.transform = .init(scaleX: previewScale, y: previewScale)
-        previewCellView.frame.origin = .init(x: previewPadding, y: previewPadding)
-
-        let previewSize = CGSize(width: previewWidth,
-                                 height: min(previewCellView.frame.height + previewPadding * 2, self.view.bounds.height * 0.4))
-
-        let previewView = UIView(frame: .init(origin: .zero, size: previewSize))
-        previewView.clipsToBounds = true
-
-        // Bubbles of own messages are translucent, on top of the menu background the chat would shine through
-        previewView.backgroundColor = .systemBackground
-        previewView.addSubview(previewCellView)
-
-        let previewController = UIViewController()
-        previewController.view = previewView
-        previewController.preferredContentSize = previewSize
-
-        return previewController
+        // Truncated, the menu needs the rest of the screen for long messages
+        return ContextMenuPreviewController(for: previewCell.contentView, maxHeight: self.view.bounds.height * 0.4)
     }
 
     // MARK: - Chat functions

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -116,9 +116,6 @@ import Toast
 
     private var photoPicker: PHPickerViewController?
 
-    private var contextMenuAccessoryView: UIView?
-    private var contextMenuMessageView: UIView?
-
     private var leftButtonLongPressGesture: UILongPressGestureRecognizer?
 
     private var messageHeightCache = NCChatMessageHeightCache()
@@ -3616,8 +3613,8 @@ import Toast
 
         let menu = UIMenu(children: actions)
 
-        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath) {
-            return nil
+        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath) { [weak self] in
+            return self?.getContextMenuPreviewController(forRowAt: indexPath)
         } actionProvider: { _ in
             return menu
         }
@@ -3626,13 +3623,6 @@ import Toast
     }
 
     public override func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
-        animator?.addAnimations {
-            // Only set these, when the context menu is fully visible
-            self.contextMenuAccessoryView?.alpha = 1
-            self.contextMenuMessageView?.layer.cornerRadius = 10
-            self.contextMenuMessageView?.layer.mask = nil
-        }
-
         // Hiding the keyboard due to a UIKit issue where the reported keyboard height
         // may be incorrect after dismissing a modal/context menu on iOS 26.
         // TODO: Recheck if this behavior is fixed on iOS 26+.
@@ -3649,116 +3639,44 @@ import Toast
         }
     }
 
-    internal func getContextMenuAccessoryView(forMessage message: NCChatMessage, forIndexPath indexPath: IndexPath, withCellHeight cellHeight: CGFloat) -> UIView? {
-        // We don't provide a accessory view in the BaseChatViewController, but can add it in a subclass
-        return nil
-    }
-
-    private class ContextMenuContainerView: UIView {
-        override func didMoveToWindow() {
-            super.didMoveToWindow()
-
-            if #available(iOS 26.0, *) {
-                // Make our context menu accessoryView user interactive
-                self.superview?.isUserInteractionEnabled = true
-            }
-        }
-    }
-
-    public override func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        guard let indexPath = configuration.identifier as? NSIndexPath,
-              let message = self.message(for: indexPath as IndexPath)
+    /// Uses a cell from the nib, not the one of the row: a cell which was displayed only renders the part of
+    /// a long message which was on screen, and handing over the live cell means UIKit reparents it
+    internal func getContextMenuPreviewController(forRowAt indexPath: IndexPath) -> UIViewController? {
+        guard let tableView = self.tableView,
+              let message = self.message(for: indexPath),
+              let previewCell = UINib(nibName: BaseChatTableViewCell.nibName, bundle: nil).instantiate(withOwner: nil).first as? BaseChatTableViewCell
         else { return nil }
 
-        let maxPreviewWidth = self.view.bounds.size.width - self.view.safeAreaInsets.left - self.view.safeAreaInsets.right
-        let maxPreviewHeight = self.view.bounds.size.height * 0.4
+        previewCell.frame = .init(origin: .zero, size: tableView.rectForRow(at: indexPath).size)
+        previewCell.setup(for: message, inRoom: self.room, forThread: self.thread, withAccount: self.account)
+        previewCell.layoutIfNeeded()
 
-        // TODO: Take padding into account
-        let maxTextWidth = maxPreviewWidth - chatMessageCellAvatarHeight
+        // Keeps the message out of the corners of the preview, which UIKit rounds stronger than our bubbles
+        let previewPadding = 12.0
+        let previewCellView = previewCell.contentView
+        let previewWidth = previewCellView.frame.width
 
-        // We need to get the height of the original cell to center the preview correctly (as the preview is always non-grouped)
-        let heightOfOriginalCell = self.getCellHeight(for: message, with: maxTextWidth)
+        // A preview wider than the cell is cut off instead of scaled, so the message makes room for the padding
+        let previewScale = (previewWidth - previewPadding * 2) / previewWidth
 
-        // Remember grouped-status -> Create a previewView which always is a non-grouped-message
-        let isGroupMessage = message.isGroupMessage
-        message.isGroupMessage = false
+        previewCellView.transform = .init(scaleX: previewScale, y: previewScale)
+        previewCellView.frame.origin = .init(x: previewPadding, y: previewPadding)
 
-        let previewTableViewCell = self.getCell(for: message)
-        var cellHeight = self.getCellHeight(for: message, with: maxTextWidth)
+        let previewSize = CGSize(width: previewWidth,
+                                 height: min(previewCellView.frame.height + previewPadding * 2, self.view.bounds.height * 0.4))
 
-        let heightDifferenceGroupedToNonGrouped = cellHeight - heightOfOriginalCell
+        let previewView = UIView(frame: .init(origin: .zero, size: previewSize))
+        previewView.clipsToBounds = true
 
-        // Cut the height if bigger than max height
-        if cellHeight > maxPreviewHeight {
-            cellHeight = maxPreviewHeight
-        }
+        // Bubbles of own messages are translucent, on top of the menu background the chat would shine through
+        previewView.backgroundColor = .systemBackground
+        previewView.addSubview(previewCellView)
 
-        let heightdifferenceOriginalToPreview = cellHeight - heightOfOriginalCell
+        let previewController = UIViewController()
+        previewController.view = previewView
+        previewController.preferredContentSize = previewSize
 
-        // Use the contentView of the UITableViewCell as a preview view
-        let previewMessageView = previewTableViewCell.contentView
-        previewMessageView.frame = CGRect(x: 0, y: 0, width: maxPreviewWidth, height: cellHeight)
-        previewMessageView.layer.masksToBounds = true
-        previewMessageView.backgroundColor = .clear
-
-        // Create a mask to not show the avatar part when showing a grouped messages while animating
-        // The mask will be reset in willDisplayContextMenuWithConfiguration so the avatar is visible when the context menu is shown
-        if heightDifferenceGroupedToNonGrouped > 0 {
-            let maskLayer = CAShapeLayer()
-            let maskRect = CGRect(x: 0, y: heightDifferenceGroupedToNonGrouped + 16, width: previewMessageView.frame.size.width, height: cellHeight - 8)
-            maskLayer.path = CGPath(rect: maskRect, transform: nil)
-
-            previewMessageView.layer.mask = maskLayer
-        }
-
-        previewMessageView.backgroundColor = .systemBackground
-        self.contextMenuMessageView = previewMessageView
-
-        // Restore grouped-status
-        message.isGroupMessage = isGroupMessage
-
-        var containerView: ContextMenuContainerView
-        var cellCenter = CGPoint()
-
-        if let accessoryView = self.getContextMenuAccessoryView(forMessage: message, forIndexPath: indexPath as IndexPath, withCellHeight: cellHeight) {
-            self.contextMenuAccessoryView = accessoryView
-
-            // maxY = height + y
-            let totalAccessoryFrameHeight = accessoryView.frame.maxY - cellHeight
-
-            containerView = ContextMenuContainerView(frame: .init(x: 0, y: 0, width: Int(maxPreviewWidth), height: Int(cellHeight + totalAccessoryFrameHeight)))
-            containerView.backgroundColor = .clear
-            containerView.addSubview(previewMessageView)
-            containerView.addSubview(accessoryView)
-
-            if let cell = tableView.cellForRow(at: indexPath as IndexPath) {
-                // On large iPhones (with regular landscape size, like iPhone X) we need to take the safe area into account when calculating the center
-                let cellCenterX = cell.center.x + self.view.safeAreaInsets.left / 2 - self.view.safeAreaInsets.right / 2
-                let cellCenterY = cell.center.y + totalAccessoryFrameHeight / 2 + heightdifferenceOriginalToPreview / 2 - heightDifferenceGroupedToNonGrouped
-                cellCenter = CGPoint(x: cellCenterX, y: cellCenterY)
-            }
-        } else {
-            containerView = ContextMenuContainerView(frame: .init(x: 0, y: 0, width: maxPreviewWidth, height: cellHeight))
-            containerView.backgroundColor = .clear
-            containerView.addSubview(previewMessageView)
-
-            if let cell = tableView.cellForRow(at: indexPath as IndexPath) {
-                // On large iPhones (with regular landscape size, like iPhone X) we need to take the safe area into account when calculating the center
-                let cellCenterX = cell.center.x + self.view.safeAreaInsets.left / 2 - self.view.safeAreaInsets.right / 2
-                let cellCenterY = cell.center.y + heightdifferenceOriginalToPreview / 2 - heightDifferenceGroupedToNonGrouped
-                cellCenter = CGPoint(x: cellCenterX, y: cellCenterY)
-            }
-        }
-
-        // Create a preview target which allows us to have a transparent background
-        let previewTarget = UIPreviewTarget(container: tableView, center: cellCenter)
-        let previewParameter = UIPreviewParameters()
-
-        // Remove the background and the drop shadow from our custom preview view
-        previewParameter.backgroundColor = .clear
-        previewParameter.shadowPath = UIBezierPath()
-
-        return UITargetedPreview(view: containerView, parameters: previewParameter, target: previewTarget)
+        return previewController
     }
 
     // MARK: - Chat functions

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -272,6 +272,11 @@ import Toast
         // Set delegate to retrieve typing events
         self.tableView?.separatorStyle = .none
 
+        if #available(iOS 26.0, *) {
+            // Our date headers make UIKit choose a hard edge, drawing a border below the navigation bar
+            self.tableView?.topEdgeEffect.style = .soft
+        }
+
         self.tableView?.register(DateHeaderView.self, forHeaderFooterViewReuseIdentifier: DateHeaderView.reuseIdentifier)
 
         self.tableView?.register(UINib(nibName: "BaseChatTableViewCell", bundle: nil), forCellReuseIdentifier: chatMessageCellIdentifier)

--- a/NextcloudTalk/Chat/BaseChatViewController.swift
+++ b/NextcloudTalk/Chat/BaseChatViewController.swift
@@ -272,6 +272,8 @@ import Toast
         // Set delegate to retrieve typing events
         self.tableView?.separatorStyle = .none
 
+        self.tableView?.register(DateHeaderView.self, forHeaderFooterViewReuseIdentifier: DateHeaderView.reuseIdentifier)
+
         self.tableView?.register(UINib(nibName: "BaseChatTableViewCell", bundle: nil), forCellReuseIdentifier: chatMessageCellIdentifier)
         self.tableView?.register(UINib(nibName: "BaseChatTableViewCell", bundle: nil), forCellReuseIdentifier: chatGroupedMessageCellIdentifier)
         self.tableView?.register(UINib(nibName: "BaseChatTableViewCell", bundle: nil), forCellReuseIdentifier: chatReplyMessageCellIdentifier)
@@ -3219,11 +3221,8 @@ import Toast
         return self.messages[dateKey]?.count ?? 0
     }
 
-    public override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if tableView != self.tableView {
-            return super.tableView(tableView, titleForHeaderInSection: section)
-        }
-
+    // Not titleForHeaderInSection, UIKit would draw that title in addition to our DateHeaderView
+    private func getHeaderTitle(forSection section: Int) -> String? {
         let date = self.dateSections[section]
         return self.getHeaderString(fromDate: date)
     }
@@ -3239,7 +3238,7 @@ import Toast
             return 0
         }
 
-        if let headerText = self.tableView(tableView, titleForHeaderInSection: section) {
+        if let headerText = self.getHeaderTitle(forSection: section) {
             return DateHeaderView.height(for: headerText, fittingWidth: tableView.frame.width)
         }
 
@@ -3251,8 +3250,10 @@ import Toast
             return super.tableView(tableView, viewForHeaderInSection: section)
         }
 
-        let headerView = DateHeaderView()
-        if let headerText = self.tableView(tableView, titleForHeaderInSection: section) {
+        // Reused, a newly created glass background would animate itself in every time
+        guard let headerView = tableView.dequeueReusableHeaderFooterView(withIdentifier: DateHeaderView.reuseIdentifier) as? DateHeaderView else { return nil }
+
+        if let headerText = self.getHeaderTitle(forSection: section) {
             headerView.titleLabel.text = headerText
             headerView.section = section
             headerView.delegate = self

--- a/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
+++ b/NextcloudTalk/Chat/Chat cells/BaseChatTableViewCell.swift
@@ -67,6 +67,8 @@ public let pollGroupedMessageCellIdentifier = "pollGroupedMessageCellIdentifier"
 
 class BaseChatTableViewCell: UITableViewCell, AudioPlayerViewDelegate, ReactionsViewDelegate {
 
+    public static let nibName = "BaseChatTableViewCell"
+
     // TODO: Reset cache when theming changes
     static var bubbleColorCache = NSCache<NSString, UIColor>()
 

--- a/NextcloudTalk/Chat/Chat views/DateHeaderView.swift
+++ b/NextcloudTalk/Chat/Chat views/DateHeaderView.swift
@@ -9,7 +9,9 @@ protocol DateHeaderViewDelegate: AnyObject {
     func dateHeaderViewTapped(inSection section: Int)
 }
 
-class DateHeaderView: UIView {
+class DateHeaderView: UITableViewHeaderFooterView {
+
+    static let reuseIdentifier = "DateHeaderView"
 
     static let maxHeight: CGFloat = 60
     static let horizontalPadding: CGFloat = 32
@@ -21,8 +23,12 @@ class DateHeaderView: UIView {
 
     public let titleLabel = PaddedLabel()
 
-    override init(frame: CGRect) {
-        super.init(frame: frame)
+    // UIKit does not adapt our colors below the navigation bar, so the label brings its own background
+    private let labelBackgroundView = UIView()
+    private var labelGlassView: UIVisualEffectView?
+
+    override init(reuseIdentifier: String?) {
+        super.init(reuseIdentifier: reuseIdentifier)
         setupView()
         setupConstraints()
         setupGesture()
@@ -36,25 +42,39 @@ class DateHeaderView: UIView {
     }
 
     private func setupView() {
-        backgroundColor = .clear
+        backgroundConfiguration = .clear()
 
         titleLabel.textAlignment = .center
         titleLabel.font = DateHeaderView.labelFont
         titleLabel.adjustsFontForContentSizeCategory = true
-        titleLabel.backgroundColor = .secondarySystemGroupedBackground
         titleLabel.textColor = .secondaryLabel
-        titleLabel.layer.cornerRadius = 8
-        titleLabel.clipsToBounds = true
+
+        labelBackgroundView.clipsToBounds = true
 
         if #available(iOS 26.0, *) {
-            // When backgroundColor is set to secondarySystemGroupedBackground, the whole view is adjusted
-            // when the header is displayed at the top of the scroll view, touching the glass effect
-            // making the label unreadable (backgroundColor then equals textColor)
-            titleLabel.backgroundColor = .clear
+            // A flat color is adjusted until it equals the text color when the header touches the navigation
+            // bar, glass stays legible, but animates itself in when created, so these views have to be reused
+            labelGlassView = labelBackgroundView.addGlassView()
+            labelGlassView?.layer.masksToBounds = true
+        } else {
+            labelBackgroundView.backgroundColor = .secondarySystemGroupedBackground
         }
 
+        addSubview(labelBackgroundView)
         addSubview(titleLabel)
+
+        labelBackgroundView.translatesAutoresizingMaskIntoConstraints = false
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        // Set here, the height depends on the font size. Glass draws its own edges, so clipping it is not enough
+        let cornerRadius = labelBackgroundView.bounds.height / 2
+
+        labelBackgroundView.layer.cornerRadius = cornerRadius
+        labelGlassView?.layer.cornerRadius = cornerRadius
     }
 
     private func setupConstraints() {
@@ -66,6 +86,11 @@ class DateHeaderView: UIView {
             titleLabel.leadingAnchor.constraint(greaterThanOrEqualTo: safeAreaLayoutGuide.leadingAnchor, constant: DateHeaderView.horizontalPadding / 2),
             titleLabel.trailingAnchor.constraint(lessThanOrEqualTo: safeAreaLayoutGuide.trailingAnchor, constant: -DateHeaderView.horizontalPadding / 2),
             titleLabel.centerXAnchor.constraint(equalTo: safeAreaLayoutGuide.centerXAnchor),
+
+            labelBackgroundView.topAnchor.constraint(equalTo: titleLabel.topAnchor),
+            labelBackgroundView.bottomAnchor.constraint(equalTo: titleLabel.bottomAnchor),
+            labelBackgroundView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
+            labelBackgroundView.trailingAnchor.constraint(equalTo: titleLabel.trailingAnchor),
 
             heightAnchor.constraint(lessThanOrEqualToConstant: DateHeaderView.maxHeight)
         ])

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -2521,7 +2521,12 @@ import SwiftUI
         }
 
         // Without this the menu would tint the emoji into a single colored shape
-        return image.withRenderingMode(.alwaysOriginal)
+        let emojiImage = image.withRenderingMode(.alwaysOriginal)
+
+        // The emoji is only drawn, so it needs a label to be read out and to be found in UI tests
+        emojiImage.accessibilityLabel = emoji
+
+        return emojiImage
     }
 
     private func getReactionShortcutMenu(for message: NCChatMessage, at indexPath: IndexPath) -> UIMenu {

--- a/NextcloudTalk/Chat/ChatViewController.swift
+++ b/NextcloudTalk/Chat/ChatViewController.swift
@@ -2505,93 +2505,66 @@ import SwiftUI
         return [pin24h, pin7d, pin30d, pinIndefinitely, UIMenu(options: .displayInline, children: [customPinAction])]
     }
 
-    override func getContextMenuAccessoryView(forMessage message: NCChatMessage, forIndexPath indexPath: IndexPath, withCellHeight cellHeight: CGFloat) -> UIView? {
-        guard self.room.canReact && self.isMessageReactable(message: message) else { return nil }
+    // A palette shows its children as a single row of images, so the emoji has to be drawn into one
+    private func getEmojiImage(for emoji: String) -> UIImage {
+        let imageSize = CGSize(width: 30, height: 30)
+        let attributes: [NSAttributedString.Key: Any] = [.font: UIFont.systemFont(ofSize: 24)]
+        let emojiSize = (emoji as NSString).size(withAttributes: attributes)
 
-        let reactionViewPadding = 10
-        let emojiButtonPadding = 10
-        let emojiButtonSize = 48
-        let frequentlyUsedEmojis = NCDatabaseManager.sharedInstance().activeAccount().frequentlyUsedEmojis
+        let image = UIGraphicsImageRenderer(size: imageSize).image { _ in
+            let emojiRect = CGRect(x: (imageSize.width - emojiSize.width) / 2,
+                                   y: (imageSize.height - emojiSize.height) / 2,
+                                   width: emojiSize.width,
+                                   height: emojiSize.height)
 
-        let totalEmojiButtonWidth = frequentlyUsedEmojis.count * emojiButtonSize
-        let totalEmojiButtonPadding = frequentlyUsedEmojis.count * emojiButtonPadding
-        let addButtonWidth = emojiButtonSize + emojiButtonPadding
+            (emoji as NSString).draw(in: emojiRect, withAttributes: attributes)
+        }
 
-        // We need to add an extra padding to the right so the buttons are correctly padded
-        let reactionViewWidth = totalEmojiButtonWidth + totalEmojiButtonPadding + addButtonWidth + emojiButtonPadding
-        let reactionView = UIView(frame: .init(x: 0, y: Int(cellHeight) + reactionViewPadding, width: reactionViewWidth, height: emojiButtonSize))
+        // Without this the menu would tint the emoji into a single colored shape
+        return image.withRenderingMode(.alwaysOriginal)
+    }
 
-        var positionX = emojiButtonPadding
+    private func getReactionShortcutMenu(for message: NCChatMessage, at indexPath: IndexPath) -> UIMenu {
+        var reactionActions: [UIMenuElement] = []
 
-        for emoji in frequentlyUsedEmojis {
-            let emojiShortcutButton = UIButton(type: .system)
-            emojiShortcutButton.frame = CGRect(x: positionX, y: 0, width: emojiButtonSize, height: emojiButtonSize)
-            emojiShortcutButton.layer.cornerRadius = CGFloat(emojiButtonSize) / 2
+        for emoji in NCDatabaseManager.sharedInstance().activeAccount().frequentlyUsedEmojis {
+            // A reaction nobody used yet does not exist on the message, so it is only added by the action
+            let reaction = message.reactionsArray().first(where: { $0.reaction == emoji }) ?? NCChatReaction(reaction: emoji)
 
-            emojiShortcutButton.titleLabel?.font = .systemFont(ofSize: 20)
-            emojiShortcutButton.setTitle(emoji, for: .normal)
-
-            if #unavailable(iOS 26.0) {
-                emojiShortcutButton.backgroundColor = .systemBackground
-            }
-
-            emojiShortcutButton.addAction { [weak self] in
+            let emojiAction = UIAction(title: emoji, image: self.getEmojiImage(for: emoji)) { [weak self] _ in
                 guard let self else { return }
-                self.tableView?.contextMenuInteraction?.dismissMenu()
 
+                // Wait for the menu to be dismissed, otherwise the message is reloaded while the menu animates
                 self.contextMenuActionBlock = {
-                    self.addReaction(reaction: emoji, to: message)
+                    self.addOrRemoveReaction(reaction: reaction, in: message)
                 }
             }
 
-            // Disable shortcuts, if we already reacted with that emoji
-            for reaction in message.reactionsArray() {
-                if reaction.reaction == emoji && reaction.userReacted {
-                    emojiShortcutButton.isEnabled = false
-                    emojiShortcutButton.alpha = 0.4
-                    break
-                }
-            }
+            // Selected when we reacted with it already, choosing it again removes the reaction, like on the message
+            emojiAction.state = reaction.userReacted ? .on : .off
 
-            reactionView.addSubview(emojiShortcutButton)
-            positionX += emojiButtonSize + emojiButtonPadding
+            reactionActions.append(emojiAction)
         }
 
-        let addReactionButton = UIButton(type: .system)
-        addReactionButton.frame = CGRect(x: positionX, y: 0, width: emojiButtonSize, height: emojiButtonSize)
-        addReactionButton.layer.cornerRadius = CGFloat(emojiButtonSize) / 2
-
-        addReactionButton.titleLabel?.font = .systemFont(ofSize: 22)
-        addReactionButton.setImage(.init(systemName: "plus"), for: .normal)
-        addReactionButton.tintColor = .label
-
-        if #unavailable(iOS 26.0) {
-            addReactionButton.backgroundColor = .systemBackground
-        }
-
-        addReactionButton.addAction { [weak self] in
+        let addReactionAction = UIAction(title: NSLocalizedString("Add reaction", comment: ""), image: .init(systemName: "plus")) { [weak self] _ in
             guard let self else { return }
-            self.tableView?.contextMenuInteraction?.dismissMenu()
 
             self.contextMenuActionBlock = {
                 self.didPressAddReaction(for: message, at: indexPath)
             }
         }
 
-        reactionView.addSubview(addReactionButton)
+        reactionActions.append(addReactionAction)
 
-        // The reactionView will be shown after the animation finishes, otherwise we see the view already when animating and this looks odd
-        reactionView.alpha = 0
-
-        if #available(iOS 26.0, *) {
-            let effectView = reactionView.addGlassView()
-            effectView.layer.cornerRadius = CGFloat(emojiButtonSize) / 2
-        } else {
-            reactionView.layer.cornerRadius = CGFloat(emojiButtonSize) / 2
-            reactionView.backgroundColor = .systemBackground
+        if #available(iOS 17.0, *) {
+            return UIMenu(options: [.displayInline, .displayAsPalette], children: reactionActions)
         }
 
-        return reactionView
+        // iOS 16 has no palettes, small elements are the closest thing, a single row of icon only entries
+        let reactionMenu = UIMenu(options: [.displayInline], children: reactionActions)
+        reactionMenu.preferredElementSize = .small
+
+        return reactionMenu
     }
 
     // swiftlint:disable:next cyclomatic_complexity
@@ -2626,6 +2599,13 @@ import SwiftUI
         var actions: [UIMenuElement] = []
         var informationalActions: [UIMenuElement] = []
 
+        // Reaction shortcuts, shown as a single row of emojis on top of the menu
+        var reactionShortcutMenu: UIMenu?
+
+        if self.isMessageReactable(message: message), self.room.canReact {
+            reactionShortcutMenu = self.getReactionShortcutMenu(for: message, at: indexPath)
+        }
+
         // Show edit information
         if let lastEditActorDisplayName = message.lastEditActorDisplayName, message.lastEditTimestamp > 0 {
             let timestampDate = Date(timeIntervalSince1970: TimeInterval(message.lastEditTimestamp))
@@ -2652,13 +2632,6 @@ import SwiftUI
         if self.isMessageReplyable(message: message), self.room.canChat, !self.textInputbar.isEditing {
             actions.append(UIAction(title: NSLocalizedString("Reply", comment: ""), image: .init(systemName: "arrowshape.turn.up.left")) { _ in
                 self.didPressReply(for: message)
-            })
-        }
-
-        // Show "Add reaction" when running on MacOS because we don't have an accessory view
-        if self.isMessageReactable(message: message), self.room.canReact, NCUtils.isiOSAppOnMac() {
-            actions.append(UIAction(title: NSLocalizedString("Add reaction", comment: ""), image: .init(systemName: "face.smiling")) { _ in
-                self.didPressAddReaction(for: message, at: indexPath)
             })
         }
 
@@ -2818,10 +2791,15 @@ import SwiftUI
             actions.append(UIMenu(options: [.displayInline], children: destructiveMenuActions))
         }
 
-        let menu = UIMenu(children: actions)
+        var menu = UIMenu(children: actions)
 
-        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath) {
-            return nil
+        // The emoji row is only separated from the other entries when those are a section of their own as well
+        if let reactionShortcutMenu {
+            menu = UIMenu(children: [reactionShortcutMenu, UIMenu(options: [.displayInline], children: actions)])
+        }
+
+        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath) { [weak self] in
+            return self?.getContextMenuPreviewController(forRowAt: indexPath)
         } actionProvider: { _ in
             return menu
         }

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -2169,8 +2169,6 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         return configuration
     }
 
-    /// Uses a cell from the nib, not the reuse pool: a label that was displayed already does not render
-    /// into a bitmap on iPad in split view, and handing over the live cell means UIKit reparents it
     private func contextMenuPreviewController(for indexPath: IndexPath) -> UIViewController? {
         guard let room = room(for: indexPath),
               let previewCell = UINib(nibName: RoomTableViewCell.nibName, bundle: nil).instantiate(withOwner: nil).first as? RoomTableViewCell
@@ -2179,35 +2177,14 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
         previewCell.frame = CGRect(origin: .zero, size: self.tableView.rectForRow(at: indexPath).size)
         configure(previewCell, for: room)
 
-        // Only set for cells the table view displays, so the preview has to do it itself
+        // Only set for cells the table view displays, so the preview does it itself
         previewCell.avatarView.setStatus(for: room, allowCustomStatusIcon: true)
 
-        // The row takes its background from the table view, the floating card needs its own
+        // The row takes its background from the table view, the card needs its own
         previewCell.containerView.backgroundColor = .systemBackground
         previewCell.layoutIfNeeded()
 
-        // Keeps the room out of the corners of the preview, which UIKit rounds stronger than the card
-        let previewPadding = 12.0
-        let previewCellView = previewCell.contentView
-        let previewWidth = previewCellView.frame.width
-
-        // A preview wider than the cell is cut off instead of scaled, so the room makes room for the padding
-        let previewScale = (previewWidth - previewPadding * 2) / previewWidth
-
-        previewCellView.transform = .init(scaleX: previewScale, y: previewScale)
-        previewCellView.frame.origin = .init(x: previewPadding, y: previewPadding)
-
-        let previewSize = CGSize(width: previewWidth, height: previewCellView.frame.height + previewPadding * 2)
-
-        let previewView = UIView(frame: .init(origin: .zero, size: previewSize))
-        previewView.backgroundColor = .systemBackground
-        previewView.addSubview(previewCellView)
-
-        let previewController = UIViewController()
-        previewController.view = previewView
-        previewController.preferredContentSize = previewSize
-
-        return previewController
+        return ContextMenuPreviewController(for: previewCell.contentView)
     }
 
     override func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {

--- a/NextcloudTalk/Rooms/RoomsTableViewController.swift
+++ b/NextcloudTalk/Rooms/RoomsTableViewController.swift
@@ -2155,8 +2155,8 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         let menu = UIMenu(title: "", children: actions)
 
-        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath, previewProvider: { () -> UIViewController? in
-            return nil
+        let configuration = UIContextMenuConfiguration(identifier: indexPath as NSIndexPath, previewProvider: { [weak self] () -> UIViewController? in
+            return self?.contextMenuPreviewController(for: indexPath)
         }, actionProvider: { _ -> UIMenu? in
             return menu
         })
@@ -2171,14 +2171,12 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
     /// Uses a cell from the nib, not the reuse pool: a label that was displayed already does not render
     /// into a bitmap on iPad in split view, and handing over the live cell means UIKit reparents it
-    private func contextMenuPreview(for indexPath: IndexPath, alpha: CGFloat) -> UITargetedPreview? {
+    private func contextMenuPreviewController(for indexPath: IndexPath) -> UIViewController? {
         guard let room = room(for: indexPath),
               let previewCell = UINib(nibName: RoomTableViewCell.nibName, bundle: nil).instantiate(withOwner: nil).first as? RoomTableViewCell
         else { return nil }
 
-        let rowRect = self.tableView.rectForRow(at: indexPath)
-
-        previewCell.frame = CGRect(origin: .zero, size: rowRect.size)
+        previewCell.frame = CGRect(origin: .zero, size: self.tableView.rectForRow(at: indexPath).size)
         configure(previewCell, for: room)
 
         // Only set for cells the table view displays, so the preview has to do it itself
@@ -2186,40 +2184,30 @@ class RoomsTableViewController: UITableViewController, CCCertificateDelegate, UI
 
         // The row takes its background from the table view, the floating card needs its own
         previewCell.containerView.backgroundColor = .systemBackground
-        previewCell.contentView.alpha = alpha
         previewCell.layoutIfNeeded()
 
-        let parameters = UIPreviewParameters()
+        // Keeps the room out of the corners of the preview, which UIKit rounds stronger than the card
+        let previewPadding = 12.0
+        let previewCellView = previewCell.contentView
+        let previewWidth = previewCellView.frame.width
 
-        // The card brings its own background, UIKit filling one in would stay behind a transparent preview
-        parameters.backgroundColor = .clear
-        parameters.visiblePath = UIBezierPath(roundedRect: previewCell.containerView.frame, cornerRadius: previewCell.containerView.layer.cornerRadius)
+        // A preview wider than the cell is cut off instead of scaled, so the room makes room for the padding
+        let previewScale = (previewWidth - previewPadding * 2) / previewWidth
 
-        // Our view is the table view, so the row rect is already in the coordinate space of the container
-        let target = UIPreviewTarget(container: self.view, center: CGPoint(x: rowRect.midX, y: rowRect.midY))
+        previewCellView.transform = .init(scaleX: previewScale, y: previewScale)
+        previewCellView.frame.origin = .init(x: previewPadding, y: previewPadding)
 
-        return UITargetedPreview(view: previewCell.contentView, parameters: parameters, target: target)
-    }
+        let previewSize = CGSize(width: previewWidth, height: previewCellView.frame.height + previewPadding * 2)
 
-    override func tableView(_ tableView: UITableView, previewForHighlightingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        if tableView != self.tableView {
-            return nil
-        }
+        let previewView = UIView(frame: .init(origin: .zero, size: previewSize))
+        previewView.backgroundColor = .systemBackground
+        previewView.addSubview(previewCellView)
 
-        guard let indexPath = configuration.identifier as? IndexPath else { return nil }
+        let previewController = UIViewController()
+        previewController.view = previewView
+        previewController.preferredContentSize = previewSize
 
-        return contextMenuPreview(for: indexPath, alpha: 1)
-    }
-
-    override func tableView(_ tableView: UITableView, previewForDismissingContextMenuWithConfiguration configuration: UIContextMenuConfiguration) -> UITargetedPreview? {
-        if tableView != self.tableView {
-            return nil
-        }
-
-        guard let indexPath = configuration.identifier as? IndexPath else { return nil }
-
-        // Describes the state the menu animates back to, so a transparent card fades the whole preview out
-        return contextMenuPreview(for: indexPath, alpha: 0)
+        return previewController
     }
 
     override func tableView(_ tableView: UITableView, willDisplayContextMenu configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {

--- a/NextcloudTalk/User Interface/ContextMenuPreviewController.swift
+++ b/NextcloudTalk/User Interface/ContextMenuPreviewController.swift
@@ -1,0 +1,42 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import UIKit
+
+/// The cell has to come from a nib, not from the reuse pool: a cell which was displayed only renders the
+/// part which was on screen, and handing over the live cell of a row means UIKit reparents it
+class ContextMenuPreviewController: UIViewController {
+
+    // Keeps the cell out of the corners of the preview, which UIKit rounds stronger than our cells
+    private static let padding = 12.0
+
+    init(for cellView: UIView, maxHeight: CGFloat = .greatestFiniteMagnitude) {
+        super.init(nibName: nil, bundle: nil)
+
+        let padding = ContextMenuPreviewController.padding
+        let cellWidth = cellView.frame.width
+
+        // A preview wider than the cell is cut off instead of scaled, so the cell makes room for the padding
+        let scale = (cellWidth - padding * 2) / cellWidth
+
+        cellView.transform = .init(scaleX: scale, y: scale)
+        cellView.frame.origin = .init(x: padding, y: padding)
+
+        let previewSize = CGSize(width: cellWidth, height: min(cellView.frame.height + padding * 2, maxHeight))
+        let previewView = UIView(frame: .init(origin: .zero, size: previewSize))
+        previewView.clipsToBounds = true
+
+        // Our cells can be translucent, the menu background behind them would shine through
+        previewView.backgroundColor = .systemBackground
+        previewView.addSubview(cellView)
+
+        self.view = previewView
+        self.preferredContentSize = previewSize
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/NextcloudTalkTests/UI/UIRoomTest.swift
+++ b/NextcloudTalkTests/UI/UIRoomTest.swift
@@ -155,7 +155,8 @@ final class UIRoomTest: XCTestCase {
         // Add a reaction to close the context menu
         // In case we are testing against a nextcloud version that does not support reactions (<= NC 23)
         // we simply tap the "Reply" button from the context menu
-        let foundElement = waitForEitherElementToExist(app.staticTexts["👍"], app.buttons["Reply"], TestConstants.timeoutShort)
+        let reactionShortcut = app.descendants(matching: .any).labelContains("👍").firstMatch
+        let foundElement = waitForEitherElementToExist(reactionShortcut, app.buttons["Reply"], TestConstants.timeoutShort)
         waitForReady(object: foundElement).tap()
 
         // Start a call and hangup afterwards
@@ -401,8 +402,9 @@ final class UIRoomTest: XCTestCase {
         // Open context menu by long-pressing on the message
         messageText.press(forDuration: 2.0)
 
-        // Tap the thumbs up reaction from the context menu (same pattern as testDeallocation)
-        let thumbsUpReaction = app.staticTexts["👍"]
+        // Tap the thumbs up shortcut of the context menu. The emoji of those entries is drawn into an image,
+        // so match on the label instead of expecting a certain element type
+        let thumbsUpReaction = app.descendants(matching: .any).labelContains("👍").firstMatch
         XCTAssert(thumbsUpReaction.waitForExistence(timeout: TestConstants.timeoutShort))
         thumbsUpReaction.tap()
 


### PR DESCRIPTION
* Since iOS 27 changes the view hierarchy again, we remove our accessoryView completely and use a palette UIMenuElement. On iOS 16 we use a fallback, since palette is iOS 17+.
* The top edge effect is different by default on 26 and 27, so we explicitly set it to have an identical look
* Add a glass view to the date headers
* Use a preview provider instead of only the highlight view. This ensures our menu is always below the preview
* Also use a preview provider in RoomsTableViewController (it has issues showing in iOS 27 otherwise. It might of course change in the final, but for now, we should go this way)

## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
