### PR TITLE
fix: Screenshare crash

### DIFF
--- a/BroadcastUploadExtension/DarwinNotificationCenter.swift
+++ b/BroadcastUploadExtension/DarwinNotificationCenter.swift
@@ -16,6 +16,7 @@ import Foundation
     static let shared = DarwinNotificationCenter()
     static let broadcastStartedNotification = "TalkiOS_BroadcastStarted"
     static let broadcastStoppedNotification = "TalkiOS_BroadcastStopped"
+    static let broadcastRequestStopNotification = "TalkiOS_BroadcastRequestStop"
 
     private let notificationCenter: CFNotificationCenter
 

--- a/BroadcastUploadExtension/SampleHandler.swift
+++ b/BroadcastUploadExtension/SampleHandler.swift
@@ -36,6 +36,10 @@ class SampleHandler: RPBroadcastSampleHandler {
         // User has requested to start the broadcast. Setup info from the UI extension can be supplied but optional.
         frameCount = 0
 
+        DarwinNotificationCenter.shared.addHandler(notificationName: DarwinNotificationCenter.broadcastRequestStopNotification, owner: self) { [weak self] in
+            self?.finishBroadcastWithoutError()
+        }
+
         DarwinNotificationCenter.shared.postNotification(DarwinNotificationCenter.broadcastStartedNotification)
         openConnection()
     }
@@ -50,6 +54,7 @@ class SampleHandler: RPBroadcastSampleHandler {
 
     override func broadcastFinished() {
         // User has requested to finish the broadcast.
+        DarwinNotificationCenter.shared.removeHandler(notificationName: DarwinNotificationCenter.broadcastRequestStopNotification, owner: self)
         DarwinNotificationCenter.shared.postNotification(DarwinNotificationCenter.broadcastStoppedNotification)
         clientConnection?.close()
     }
@@ -77,13 +82,26 @@ private extension SampleHandler {
             if let error = error {
                 self?.finishBroadcastWithError(error)
             } else {
-                // the displayed failure message is more user friendly when using NSError instead of Error
-                let JMScreenSharingStopped = 10001
-                let localizedError = NSLocalizedString("Screensharing stopped", comment: "")
-                let customError = NSError(domain: RPRecordingErrorDomain, code: JMScreenSharingStopped, userInfo: [NSLocalizedDescriptionKey: localizedError])
-                self?.finishBroadcastWithError(customError)
+                self?.finishBroadcastWithoutError()
             }
         }
+    }
+
+    // a nil error ends the broadcast without the system error dialog, which Swift does not allow
+    func finishBroadcastWithoutError() {
+        let selector = NSSelectorFromString("finishBroadcastWithError:")
+
+        guard responds(to: selector) else {
+            // the displayed failure message is more user friendly when using NSError instead of Error
+            let JMScreenSharingStopped = 10001
+            let localizedError = NSLocalizedString("Screensharing stopped", comment: "")
+            let customError = NSError(domain: RPRecordingErrorDomain, code: JMScreenSharingStopped, userInfo: [NSLocalizedDescriptionKey: localizedError])
+            finishBroadcastWithError(customError)
+
+            return
+        }
+
+        _ = perform(selector, with: nil)
     }
 
     func openConnection() {

--- a/BroadcastUploadExtension/SampleUploader.swift
+++ b/BroadcastUploadExtension/SampleUploader.swift
@@ -42,10 +42,13 @@ class SampleUploader {
 
         isReady = false
 
-        dataToSend = prepare(sample: buffer)
-        byteIndex = 0
+        // the sample is encoded here on the ReplayKit thread, but the state sendDataChunk() walks
+        // through belongs to serialQueue alone
+        let data = prepare(sample: buffer)
 
         serialQueue.async { [weak self] in
+            self?.dataToSend = data
+            self?.byteIndex = 0
             self?.sendDataChunk()
         }
 

--- a/BroadcastUploadExtension/SampleUploader.swift
+++ b/BroadcastUploadExtension/SampleUploader.swift
@@ -42,8 +42,7 @@ class SampleUploader {
 
         isReady = false
 
-        // the sample is encoded here on the ReplayKit thread, but the state sendDataChunk() walks
-        // through belongs to serialQueue alone
+        // the state sendDataChunk() walks through belongs to serialQueue alone
         let data = prepare(sample: buffer)
 
         serialQueue.async { [weak self] in

--- a/BroadcastUploadExtension/SocketConnection.swift
+++ b/BroadcastUploadExtension/SocketConnection.swift
@@ -20,11 +20,16 @@ class SocketConnection: NSObject {
     private var socketHandle: Int32 = -1
     private var address: sockaddr_un?
 
+    // CFStream is not thread safe and close() arrives from ReplayKit or from a stream event while
+    // the uploader queue is in the middle of a write, so all stream access is serialized here
+    private let streamQueue = DispatchQueue(label: "talk.broadcast.socketConnection")
+
     private var inputStream: InputStream?
     private var outputStream: OutputStream?
 
-    private var networkQueue: DispatchQueue?
-    private var shouldKeepRunning = false
+    private var streamThread: Thread?
+    private var streamRunLoop: RunLoop?
+    private var isClosed = false
 
     init?(filePath path: String) {
         filePath = path
@@ -52,60 +57,71 @@ class SocketConnection: NSObject {
             return false
         }
 
-        setupStreams()
+        return streamQueue.sync { () -> Bool in
+            guard !isClosed else {
+                return false
+            }
 
-        inputStream?.open()
-        outputStream?.open()
+            setupStreams()
 
-        return true
+            inputStream?.open()
+            outputStream?.open()
+
+            return true
+        }
     }
 
     func close() {
-        unscheduleStreams()
-
-        inputStream?.delegate = nil
-        outputStream?.delegate = nil
-
-        inputStream?.close()
-        outputStream?.close()
-
-        inputStream = nil
-        outputStream = nil
+        streamQueue.sync { () -> Void in
+            self.closeStreams()
+        }
     }
 
     func writeToStream(buffer: UnsafePointer<UInt8>, maxLength length: Int) -> Int {
-        outputStream?.write(buffer, maxLength: length) ?? 0
+        streamQueue.sync {
+            outputStream?.write(buffer, maxLength: length) ?? 0
+        }
     }
 }
 
 extension SocketConnection: StreamDelegate {
 
+    // stream events are delivered on the run loop thread set up in scheduleStreams()
     func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
         switch eventCode {
         case .openCompleted:
             print("client stream open completed")
-            if aStream == outputStream {
+            if isOutputStream(aStream) {
                 didOpen?()
             }
         case .hasBytesAvailable:
-            if aStream == inputStream {
-                var buffer: UInt8 = 0
-                let numberOfBytesRead = inputStream?.read(&buffer, maxLength: 1)
-                if numberOfBytesRead == 0 && aStream.streamStatus == .atEnd {
-                    print("server socket closed")
-                    close()
+            guard isInputStream(aStream) else {
+                break
+            }
+
+            var buffer: UInt8 = 0
+            let numberOfBytesRead = streamQueue.sync {
+                self.inputStream?.read(&buffer, maxLength: 1)
+            }
+
+            if numberOfBytesRead == 0 && aStream.streamStatus == .atEnd {
+                print("server socket closed")
+
+                if streamQueue.sync(execute: { self.closeStreams() }) {
                     notifyDidClose(error: nil)
                 }
             }
         case .hasSpaceAvailable:
-            if aStream == outputStream {
+            if isOutputStream(aStream) {
                 streamHasSpaceAvailable?()
             }
         case .errorOccurred:
             print("client stream error occured: \(String(describing: aStream.streamError))")
-            close()
-            notifyDidClose(error: aStream.streamError)
+            let streamError = aStream.streamError
 
+            if streamQueue.sync(execute: { self.closeStreams() }) {
+                notifyDidClose(error: streamError)
+            }
         default:
             break
         }
@@ -113,6 +129,14 @@ extension SocketConnection: StreamDelegate {
 }
 
 private extension SocketConnection {
+
+    func isInputStream(_ aStream: Stream) -> Bool {
+        streamQueue.sync { aStream === self.inputStream }
+    }
+
+    func isOutputStream(_ aStream: Stream) -> Bool {
+        streamQueue.sync { aStream === self.outputStream }
+    }
 
     func setupAddress() -> Bool {
         var addr = sockaddr_un()
@@ -150,6 +174,7 @@ private extension SocketConnection {
         return true
     }
 
+    // must be called on streamQueue
     func setupStreams() {
         var readStream: Unmanaged<CFReadStream>?
         var writeStream: Unmanaged<CFWriteStream>?
@@ -164,33 +189,79 @@ private extension SocketConnection {
         outputStream?.delegate = self
         outputStream?.setProperty(kCFBooleanTrue, forKey: Stream.PropertyKey(kCFStreamPropertyShouldCloseNativeSocket as String))
 
-        scheduleStreams()
-    }
-
-    func scheduleStreams() {
-        shouldKeepRunning = true
-
-        networkQueue = DispatchQueue.global(qos: .userInitiated)
-        networkQueue?.async { [weak self] in
-            self?.inputStream?.schedule(in: .current, forMode: .common)
-            self?.outputStream?.schedule(in: .current, forMode: .common)
-            RunLoop.current.run()
-
-            var isRunning = false
-
-            repeat {
-                isRunning = self?.shouldKeepRunning ?? false && RunLoop.current.run(mode: .default, before: .distantFuture)
-            } while (isRunning)
+        if let inputStream = inputStream, let outputStream = outputStream {
+            scheduleStreams(inputStream, outputStream)
         }
     }
 
-    func unscheduleStreams() {
-        networkQueue?.sync { [weak self] in
-            self?.inputStream?.remove(from: .current, forMode: .common)
-            self?.outputStream?.remove(from: .current, forMode: .common)
+    // the streams get a thread of their own instead of a global queue, so closeStreams() knows
+    // which run loop they ended up on and can take them off it again
+    // must be called on streamQueue
+    func scheduleStreams(_ input: InputStream, _ output: OutputStream) {
+        let thread = Thread { [weak self] in
+            guard let self = self else {
+                return
+            }
+
+            let runLoop = RunLoop.current
+            let scheduled = self.streamQueue.sync { () -> Bool in
+                guard !self.isClosed else {
+                    return false
+                }
+
+                self.streamRunLoop = runLoop
+                input.schedule(in: runLoop, forMode: .common)
+                output.schedule(in: runLoop, forMode: .common)
+
+                return true
+            }
+
+            guard scheduled else {
+                return
+            }
+
+            while !Thread.current.isCancelled, runLoop.run(mode: .default, before: .distantFuture) {
+                // run() returns once the streams are unscheduled, which ends the thread
+            }
         }
 
-        shouldKeepRunning = false
+        thread.name = "talk.broadcast.socketConnection"
+        streamThread = thread
+        thread.start()
+    }
+
+    // returns whether this call was the one that closed the connection, so that a close coming in
+    // twice, on a stream error and on the server hanging up, only reports back once
+    // must be called on streamQueue
+    @discardableResult
+    func closeStreams() -> Bool {
+        guard !isClosed else {
+            return false
+        }
+
+        isClosed = true
+
+        streamThread?.cancel()
+
+        if let streamRunLoop = streamRunLoop {
+            inputStream?.remove(from: streamRunLoop, forMode: .common)
+            outputStream?.remove(from: streamRunLoop, forMode: .common)
+            CFRunLoopStop(streamRunLoop.getCFRunLoop())
+        }
+
+        inputStream?.delegate = nil
+        outputStream?.delegate = nil
+
+        inputStream?.close()
+        outputStream?.close()
+
+        inputStream = nil
+        outputStream = nil
+
+        streamThread = nil
+        streamRunLoop = nil
+
+        return true
     }
 
     func notifyDidClose(error: Error?) {

--- a/BroadcastUploadExtension/SocketConnection.swift
+++ b/BroadcastUploadExtension/SocketConnection.swift
@@ -20,8 +20,7 @@ class SocketConnection: NSObject {
     private var socketHandle: Int32 = -1
     private var address: sockaddr_un?
 
-    // CFStream is not thread safe and close() arrives from ReplayKit or from a stream event while
-    // the uploader queue is in the middle of a write, so all stream access is serialized here
+    // CFStream is not thread safe, so all stream access is serialized here
     private let streamQueue = DispatchQueue(label: "talk.broadcast.socketConnection")
 
     private var inputStream: InputStream?
@@ -86,7 +85,6 @@ class SocketConnection: NSObject {
 
 extension SocketConnection: StreamDelegate {
 
-    // stream events are delivered on the run loop thread set up in scheduleStreams()
     func stream(_ aStream: Stream, handle eventCode: Stream.Event) {
         switch eventCode {
         case .openCompleted:
@@ -110,6 +108,12 @@ extension SocketConnection: StreamDelegate {
                 if streamQueue.sync(execute: { self.closeStreams() }) {
                     notifyDidClose(error: nil)
                 }
+            }
+        case .endEncountered:
+            print("client stream end encountered")
+
+            if streamQueue.sync(execute: { self.closeStreams() }) {
+                notifyDidClose(error: nil)
             }
         case .hasSpaceAvailable:
             if isOutputStream(aStream) {
@@ -174,7 +178,6 @@ private extension SocketConnection {
         return true
     }
 
-    // must be called on streamQueue
     func setupStreams() {
         var readStream: Unmanaged<CFReadStream>?
         var writeStream: Unmanaged<CFWriteStream>?
@@ -194,9 +197,7 @@ private extension SocketConnection {
         }
     }
 
-    // the streams get a thread of their own instead of a global queue, so closeStreams() knows
-    // which run loop they ended up on and can take them off it again
-    // must be called on streamQueue
+    // a dedicated thread, so closeStreams() can unschedule the streams from the right run loop
     func scheduleStreams(_ input: InputStream, _ output: OutputStream) {
         let thread = Thread { [weak self] in
             guard let self = self else {
@@ -220,9 +221,7 @@ private extension SocketConnection {
                 return
             }
 
-            while !Thread.current.isCancelled, runLoop.run(mode: .default, before: .distantFuture) {
-                // run() returns once the streams are unscheduled, which ends the thread
-            }
+            while !Thread.current.isCancelled, runLoop.run(mode: .default, before: .distantFuture) {}
         }
 
         thread.name = "talk.broadcast.socketConnection"
@@ -230,9 +229,7 @@ private extension SocketConnection {
         thread.start()
     }
 
-    // returns whether this call was the one that closed the connection, so that a close coming in
-    // twice, on a stream error and on the server hanging up, only reports back once
-    // must be called on streamQueue
+    // returns whether this call was the one that closed, so a doubled close only reports back once
     @discardableResult
     func closeStreams() -> Bool {
         guard !isClosed else {

--- a/NextcloudTalk/Calls/NCCallController.swift
+++ b/NextcloudTalk/Calls/NCCallController.swift
@@ -776,6 +776,9 @@ internal class NCCallController: NSObject, NCPeerConnectionDelegate, NCSignaling
 
         guard self.screensharingActive else { return }
 
+        // otherwise the broadcast keeps running until the system notices nobody consumes it
+        DarwinNotificationCenter.shared.postNotification(DarwinNotificationCenter.broadcastRequestStopNotification)
+
         self.screensharingController.stopCapture()
 
         if let externalSignalingController {

--- a/NextcloudTalk/Screensharing/SocketConnection.m
+++ b/NextcloudTalk/Screensharing/SocketConnection.m
@@ -58,10 +58,12 @@
 
         self.inputStream = (__bridge_transfer NSInputStream *)readStream;
         self.inputStream.delegate = streamDelegate;
-        [self.inputStream setProperty:@"kCFBooleanTrue" forKey:@"kCFStreamPropertyShouldCloseNativeSocket"];
+
+        // a string value is ignored here and leaves the accepted socket open on close
+        [self.inputStream setProperty:(__bridge id)kCFBooleanTrue forKey:(__bridge NSString *)kCFStreamPropertyShouldCloseNativeSocket];
 
         self.outputStream = (__bridge_transfer NSOutputStream *)writeStream;
-        [self.outputStream setProperty:@"kCFBooleanTrue" forKey:@"kCFStreamPropertyShouldCloseNativeSocket"];
+        [self.outputStream setProperty:(__bridge id)kCFBooleanTrue forKey:(__bridge NSString *)kCFStreamPropertyShouldCloseNativeSocket];
 
         dispatch_async(dispatch_get_main_queue(), ^{
             [self scheduleStreams];


### PR DESCRIPTION
This PR
* Fixes a crash due to a race condition as seen on AppStoreConnect
* Fixes closing the streams
* Cleanly closes the broadcast extension when the call is ended (currently it shows an error message)


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
