### PR TITLE
fix: Use thread safe dictionary instead NSCache

### DIFF
--- a/NextcloudTalk/Network/NCAPIController.swift
+++ b/NextcloudTalk/Network/NCAPIController.swift
@@ -27,8 +27,8 @@ class NCAPIController: NSObject, NKCommonDelegate {
     private let kNCOCSAPIVersion = "/ocs/v2.php"
     private let kNCSpreedAPIVersionBase = "/apps/spreed/api/v"
 
-    private var authTokenCache = NSCache<NSString, NSString>()
-    private var requestModifierCache = NSCache<NSString, SDWebImageDownloaderRequestModifier>()
+    private var authTokenCache = ThreadSafeDictionary<String, String>()
+    private var requestModifierCache = ThreadSafeDictionary<String, SDWebImageDownloaderRequestModifier>()
 
     private lazy var defaultAPISessionManager: NCAPISessionManager = {
         let configuration = URLSessionConfiguration.default
@@ -36,12 +36,10 @@ class NCAPIController: NSObject, NKCommonDelegate {
         return NCAPISessionManager(configuration: configuration)
     }()
 
-    // It's possible that we access the dictionary from multiple threads (e.g. in background-fetch)
-    // therefore we use NSCache as it is thread-safe - swift dictionaries are not
-    private var cookieStorages = NSCache<NSString, HTTPCookieStorage>()
-    private var apiSessionManagers = NSCache<NSString, NCAPISessionManager>()
-    private var longPollingApiSessionManagers = NSCache<NSString, NCAPISessionManager>()
-    private var calDAVSessionManagers = NSCache<NSString, NCCalDAVSessionManager>()
+    private var cookieStorages = ThreadSafeDictionary<String, HTTPCookieStorage>()
+    private var apiSessionManagers = ThreadSafeDictionary<String, NCAPISessionManager>()
+    private var longPollingApiSessionManagers = ThreadSafeDictionary<String, NCAPISessionManager>()
+    private var calDAVSessionManagers = ThreadSafeDictionary<String, NCCalDAVSessionManager>()
 
     enum ApiControllerError: Error {
         case preconditionError
@@ -58,18 +56,17 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
     // Ensure we use the same HTTPCookieStorage object for all session managers
     internal func getHTTPCookieStorage(forAccountId accountId: String) -> HTTPCookieStorage {
-        if let cachedCookieStorage = self.cookieStorages.object(forKey: accountId as NSString) {
+        if let cachedCookieStorage = self.cookieStorages[accountId] {
             return cachedCookieStorage
         }
 
         let newCookieStorage = HTTPCookieStorage.sharedCookieStorage(forGroupContainerIdentifier: accountId)
-        self.cookieStorages.setObject(newCookieStorage, forKey: accountId as NSString)
 
-        return newCookieStorage
+        return self.cookieStorages.setIfAbsent(newCookieStorage, forKey: accountId)
     }
 
     public func getAPISessionManager(forAccountId accountId: String) -> NCAPISessionManager? {
-        if let cachedSessionManager = self.apiSessionManagers.object(forKey: accountId as NSString) {
+        if let cachedSessionManager = self.apiSessionManagers[accountId] {
             return cachedSessionManager
         }
 
@@ -84,13 +81,13 @@ class NCAPIController: NSObject, NKCommonDelegate {
 
         // As we can run max. 30s in the background, the default timeout should be lower than 30 to avoid being killed by the OS
         apiSessionManager.requestSerializer.timeoutInterval = TimeInterval(25)
-        apiSessionManagers.setObject(apiSessionManager, forKey: accountId as NSString)
+        apiSessionManagers[accountId] = apiSessionManager
 
         return apiSessionManager
     }
 
     internal func getLongPollingAPISessionManager(forAccountId accountId: String) -> NCAPISessionManager? {
-        if let cachedSessionManager = self.longPollingApiSessionManagers.object(forKey: accountId as NSString) {
+        if let cachedSessionManager = self.longPollingApiSessionManagers[accountId] {
             return cachedSessionManager
         }
 
@@ -102,13 +99,13 @@ class NCAPIController: NSObject, NKCommonDelegate {
         longConfiguration.httpCookieStorage = self.getHTTPCookieStorage(forAccountId: accountId)
         let longApiSessionManager = NCAPISessionManager(configuration: longConfiguration)
         longApiSessionManager.requestSerializer.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        longPollingApiSessionManagers.setObject(longApiSessionManager, forKey: accountId as NSString)
+        longPollingApiSessionManagers[accountId] = longApiSessionManager
 
         return longApiSessionManager
     }
 
     internal func getCalDAVSessionManager(forAccountId accountId: String) -> NCCalDAVSessionManager? {
-        if let cachedSessionManager = self.calDAVSessionManagers.object(forKey: accountId as NSString) {
+        if let cachedSessionManager = self.calDAVSessionManagers[accountId] {
             return cachedSessionManager
         }
 
@@ -120,17 +117,17 @@ class NCAPIController: NSObject, NKCommonDelegate {
         calDAVConfiguration.httpCookieStorage = self.getHTTPCookieStorage(forAccountId: accountId)
         let calDAVSessionManager = NCCalDAVSessionManager(configuration: calDAVConfiguration)
         calDAVSessionManager.requestSerializer.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        calDAVSessionManagers.setObject(calDAVSessionManager, forKey: accountId as NSString)
+        calDAVSessionManagers[accountId] = calDAVSessionManager
 
         return calDAVSessionManager
     }
 
     public func removeAPISessionManager(forAccount account: TalkAccount) {
-        self.authTokenCache.removeObject(forKey: account.accountId as NSString)
-        self.requestModifierCache.removeObject(forKey: account.accountId as NSString)
-        self.apiSessionManagers.removeObject(forKey: account.accountId as NSString)
-        self.longPollingApiSessionManagers.removeObject(forKey: account.accountId as NSString)
-        self.calDAVSessionManagers.removeObject(forKey: account.accountId as NSString)
+        self.authTokenCache.removeValue(forKey: account.accountId)
+        self.requestModifierCache.removeValue(forKey: account.accountId)
+        self.apiSessionManagers.removeValue(forKey: account.accountId)
+        self.longPollingApiSessionManagers.removeValue(forKey: account.accountId)
+        self.calDAVSessionManagers.removeValue(forKey: account.accountId)
 
         let cookieStorage = self.getHTTPCookieStorage(forAccountId: account.accountId)
         if let cookies = cookieStorage.cookies {
@@ -138,12 +135,12 @@ class NCAPIController: NSObject, NKCommonDelegate {
                 cookieStorage.deleteCookie(cookie)
             }
         }
-        self.cookieStorages.removeObject(forKey: account.accountId as NSString)
+        self.cookieStorages.removeValue(forKey: account.accountId)
     }
 
     private func authHeader(forAccount account: TalkAccount) -> String? {
-        if let cachedHeader = self.authTokenCache.object(forKey: account.accountId as NSString) {
-            return cachedHeader as String
+        if let cachedHeader = self.authTokenCache[account.accountId] {
+            return cachedHeader
         }
 
         guard let token = NCKeyChainController.sharedInstance().token(forAccountId: account.accountId)
@@ -154,7 +151,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
         let base64Encoded = data.base64EncodedString()
 
         let authHeader = "Basic \(base64Encoded)"
-        self.authTokenCache.setObject(authHeader as NSString, forKey: account.accountId as NSString)
+        self.authTokenCache[account.accountId] = authHeader
 
         return authHeader
     }
@@ -194,7 +191,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
     }
 
     internal func getRequestModifier(forAccount account: TalkAccount) -> SDWebImageDownloaderRequestModifier? {
-        if let cachedModifier = self.requestModifierCache.object(forKey: account.accountId as NSString) {
+        if let cachedModifier = self.requestModifierCache[account.accountId] {
             return cachedModifier
         }
 
@@ -206,7 +203,7 @@ class NCAPIController: NSObject, NKCommonDelegate {
         ]
 
         let requestModifier = SDWebImageDownloaderRequestModifier(headers: headers)
-        self.requestModifierCache.setObject(requestModifier, forKey: account.accountId as NSString)
+        self.requestModifierCache[account.accountId] = requestModifier
 
         return requestModifier
     }

--- a/NextcloudTalk/Network/NCBaseSessionManager.swift
+++ b/NextcloudTalk/Network/NCBaseSessionManager.swift
@@ -5,7 +5,7 @@
 
 import Foundation
 
-@objcMembers public class NCBaseSessionManager: AFHTTPSessionManager, NSDiscardableContent {
+@objcMembers public class NCBaseSessionManager: AFHTTPSessionManager {
 
     public var userAgent: String = NCAppBranding.userAgent()
 
@@ -36,20 +36,5 @@ import Foundation
         } else {
             completionHandler(.performDefaultHandling, nil)
         }
-    }
-
-    public func beginContentAccess() -> Bool {
-        return true
-    }
-
-    public func endContentAccess() {
-    }
-
-    public func discardContentIfPossible() {
-    }
-
-    public func isContentDiscarded() -> Bool {
-        // Return false to not get evicated from NSCache when moving to background
-        return false
     }
 }

--- a/NextcloudTalk/Network/ThreadSafeDictionary.swift
+++ b/NextcloudTalk/Network/ThreadSafeDictionary.swift
@@ -1,0 +1,52 @@
+//
+// SPDX-FileCopyrightText: 2026 Nextcloud GmbH and Nextcloud contributors
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+
+import Foundation
+
+/// NSCache is thread safe as well, but it evicts when the app moves to the background, which loses the
+/// identity of values that callers keep a reference to. Ref https://github.com/nextcloud/spreed/issues/19197
+class ThreadSafeDictionary<Key: Hashable, Value> {
+
+    private var storage = [Key: Value]()
+    private let lock = NSLock()
+
+    subscript(key: Key) -> Value? {
+        get {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+
+            return self.storage[key]
+        }
+
+        set {
+            self.lock.lock()
+            defer { self.lock.unlock() }
+
+            self.storage[key] = newValue
+        }
+    }
+
+    /// The first stored value wins, so callers racing on a key all end up with the same instance
+    @discardableResult
+    func setIfAbsent(_ value: Value, forKey key: Key) -> Value {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        if let existingValue = self.storage[key] {
+            return existingValue
+        }
+
+        self.storage[key] = value
+
+        return value
+    }
+
+    func removeValue(forKey key: Key) {
+        self.lock.lock()
+        defer { self.lock.unlock() }
+
+        self.storage.removeValue(forKey: key)
+    }
+}


### PR DESCRIPTION
* Ref: https://github.com/nextcloud/spreed/issues/19197

Not a fix for the linked issue, but a safeguard for the 404 on the signaling endpoint. The cookieStorage does not outlive a background enter. So if the long polling session manager is created after a background event, it could end up with a different cookie storage.


## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
