### PR TITLE
fix: Don't retry join on non-recoverable errors

### DIFF
--- a/NextcloudTalk/Rooms/NCRoomsManager.swift
+++ b/NextcloudTalk/Rooms/NCRoomsManager.swift
@@ -1016,7 +1016,9 @@ class NCRoomsManager: NSObject, CallViewControllerDelegate {
                 // Set room as active
                 self.activeRooms[token] = controller
             } else {
-                if self.joiningAttempts < 3 && statusCode != 403 {
+                // Some request are not recoverable by a retry - don't even try it
+                let nonRecoverableErrorCodes = [403, 429, 503]
+                if self.joiningAttempts < 3 && !nonRecoverableErrorCodes.contains(statusCode) {
                     NCLog.log("Error joining room, retrying. \(self.joiningAttempts)")
                     self.joiningAttempts += 1
                     self.joinRoomHelper(token, forAccountId: accountId, forCall: call)


### PR DESCRIPTION
No need to retry these, we will not recover anyway.

## 🤖 AI (if applicable)

- [ ] The content of this PR was partly or fully generated using AI
